### PR TITLE
Přidat lepší typové anotace

### DIFF
--- a/pisek/generator.py
+++ b/pisek/generator.py
@@ -57,10 +57,11 @@ class OfflineGenerator(Program):
     the generator a directory into which to generate outputs.
     """
 
-    def generate(self, test_dir):
+    def generate(self, test_dir: str) -> bool:
         self.compile_if_needed()
         os.makedirs(test_dir, exist_ok=True)
 
+        assert self.executable is not None
         result = subprocess.run([self.executable, test_dir])
 
         return result.returncode == 0

--- a/pisek/judge.py
+++ b/pisek/judge.py
@@ -7,11 +7,11 @@ from . import util
 
 
 class Verdict:
-    def __init__(self, run_result, msg=None) -> None:
+    def __init__(self, run_result: RunResult, msg: Optional[str] = None) -> None:
         self.result: RunResult = run_result
-        self.msg: str = msg
+        self.msg: Optional[str] = msg
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Verdict(result={self.result}, msg={self.msg})"
 
 
@@ -86,14 +86,10 @@ class WhiteDiffJudge(Judge):
                 "Cannot diff solution with correct output, because the output is not given"
             )
 
-        def white_diff(output_file: str):
-            correct_output_but_named_differently_because_of_damn_mypy_not_being_able_to_recognize_it_as_definitely_not_being_null = cast(
-                str, correct_output
-            )
-            if util.files_are_equal(
-                output_file,
-                correct_output_but_named_differently_because_of_damn_mypy_not_being_able_to_recognize_it_as_definitely_not_being_null,
-            ):
+        def white_diff(output_file: str) -> Tuple[float, Verdict]:
+            assert correct_output is not None
+
+            if util.files_are_equal(output_file, correct_output):
                 return 1.0, Verdict(RunResult.OK)
             else:
                 return 0.0, Verdict(RunResult.OK)
@@ -120,7 +116,7 @@ class ExternalJudge(Judge):
         correct_output: Optional[str],
         run_config: Optional[Dict[str, Any]] = None,
     ) -> Tuple[float, Verdict]:
-        def external_judge(output_file: str):
+        def external_judge(output_file: str) -> Tuple[float, Verdict]:
             # TODO: impose limits
             args = (
                 [input_file, correct_output, output_file]
@@ -128,7 +124,7 @@ class ExternalJudge(Judge):
                 else [input_file, output_file]
             )
             result = self.judge.run_raw(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             if result.returncode != 0:
                 raise RuntimeError(

--- a/pisek/program.py
+++ b/pisek/program.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import Optional, List
+from typing import Optional, List, Any
 from enum import Enum
 
 from . import util
@@ -104,7 +104,7 @@ class Program:
         return run_direct(self.executable, args)
 
     def run_raw(
-        self, program_args: List[str], *args, **kwargs
+        self, program_args: List[str], *args: Any, **kwargs: Any
     ) -> subprocess.CompletedProcess:
         self.compile_if_needed()
         assert self.executable is not None

--- a/pisek/task_config.py
+++ b/pisek/task_config.py
@@ -45,14 +45,16 @@ class TaskConfig:
         except Exception as e:
             raise RuntimeError("Chyba při načítání configu") from e
 
-    def get_maximum_score(self):
+    def get_maximum_score(self) -> int:
         return sum([subtask.score for subtask in self.subtasks.values()])
 
 
 class SubtaskConfig:
-    def __init__(self, contest_type, config_section):
-        self.name = config_section.get("name", None)
-        self.score = int(config_section["points"])
+    def __init__(
+        self, contest_type: str, config_section: configparser.SectionProxy
+    ) -> None:
+        self.name: Optional[str] = config_section.get("name", None)
+        self.score: int = int(config_section["points"])
 
         if contest_type == "cms":
-            self.in_globs = config_section["in_globs"].split()
+            self.in_globs: List[str] = config_section["in_globs"].split()

--- a/pisek/util.py
+++ b/pisek/util.py
@@ -136,7 +136,7 @@ def get_output_name(input_file: str, solution_name: str) -> str:
     )
 
 
-def _clean_subdirs(task_dir: str, subdirs: List[str]):
+def _clean_subdirs(task_dir: str, subdirs: List[str]) -> None:
     config = TaskConfig(task_dir)
     # XXX: ^ safeguard, raises an exception if task_dir isn't really a task
     # directory
@@ -148,11 +148,11 @@ def _clean_subdirs(task_dir: str, subdirs: List[str]):
             pass
 
 
-def clean_data_dir(task_dir: str):
+def clean_data_dir(task_dir: str) -> None:
     return _clean_subdirs(task_dir, [DATA_DIR])
 
 
-def clean_task_dir(task_dir: str):
+def clean_task_dir(task_dir: str) -> None:
     return _clean_subdirs(task_dir, [DATA_DIR, BUILD_DIR])
 
 


### PR DESCRIPTION
Přidal jsem typové anotace základní knihovny (tj. mimo podložky `tests/` a souboru `main.py`) tak,
aby byl MyPy spokojen i na `--strict` úrovni.
Zároveň jsem poupravil kousky stávajících castů a anotacích, které byly nesprávné/nedostatečné/zvláštní.

Funkčnost jsem netestoval, nechám to na self-testech přes GitHub CI. ¯\\\_(ツ)_/¯

Prosím o zběžnou kontrolu, @RichardHladik nebo @IAmWave.