### PR TITLE
Detailnější výpis jednotlivých testů

### DIFF
--- a/pisek/self_tests/util.py
+++ b/pisek/self_tests/util.py
@@ -40,7 +40,7 @@ class TestFixtureVariant(unittest.TestCase):
         # We lower the timeout to make the self-tests run faster. The solutions
         # run instantly, with the exception of `solve_slow_4b`, which takes 10 seconds
         # and we want to consider it a timeout
-        suite = get_test_suite(self.task_dir, timeout=1)
+        suite = get_test_suite(self.task_dir, timeout=1, in_self_test=True)
 
         # with open(os.devnull, "w") as devnull:
         output = io.StringIO()

--- a/pisek/tests/cms_test_suite.py
+++ b/pisek/tests/cms_test_suite.py
@@ -54,7 +54,7 @@ class SolutionWorks(test_case.SolutionTestCase):
         super().__init__(task_dir, solution_name)
         self.run_config = {"timeout": timeout}
         self.task_config = TaskConfig(self.task_dir)
-        self.judge = make_judge(self.task_dir, self.task_config)
+        self.judge: Judge = make_judge(self.task_dir, self.task_config)
 
     def test_passes_samples(self):
         for sample_in, sample_out in util.get_samples(self.task_dir):
@@ -91,6 +91,17 @@ class SolutionWorks(test_case.SolutionTestCase):
                 run_config=self.run_config,
             )
 
+            result_chars = {
+                RunResult.TIMEOUT: "T",
+                RunResult.NONZERO_EXIT_CODE: "!",
+            }
+            if verdict.result == RunResult.OK:
+                c = "." if pts == 1 else "W" if pts == 0 else "P"
+            else:
+                c = result_chars[verdict.result]
+
+            self.log(c, end="")
+
             judge_score = min(judge_score, pts)
 
             if judge_score == 0:
@@ -110,11 +121,14 @@ class SolutionWorks(test_case.SolutionTestCase):
             self.test_passes_samples()
 
         score = 0
-        for subtask in self.task_config.subtasks:
+        for i, subtask in enumerate(self.task_config.subtasks):
+            self.log("|", end="")
             max_subtask_score = self.task_config.subtasks[subtask].score
             judge_score = self.get_subtask_score(subtask)
             score += judge_score * max_subtask_score
+        self.log("| ", end="")
 
+        # TODO: document this somewhere
         score = round(score)
 
         # TODO: add diffs

--- a/pisek/tests/kasiopea_test_suite.py
+++ b/pisek/tests/kasiopea_test_suite.py
@@ -261,6 +261,7 @@ def kasiopea_test_suite(
     solutions: Optional[List[str]] = None,
     n_seeds=5,
     timeout=util.DEFAULT_TIMEOUT,
+    in_self_test=False,
 ):
     """
     Tests a task. Generates test cases using the generator, then runs each solution

--- a/pisek/tests/test_case.py
+++ b/pisek/tests/test_case.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import unittest
 
 from ..task_config import TaskConfig
@@ -10,6 +11,10 @@ class TestCase(unittest.TestCase):
     def __init__(self, task_dir):
         super().__init__()
         self.task_dir = task_dir
+
+    def log(self, msg, *args, **kwargs):
+        print(msg, file=sys.stderr, *args, **kwargs)
+        sys.stderr.flush()
 
 
 class SolutionTestCase(TestCase):


### PR DESCRIPTION
Při testování CMS test suite Písek pro každé řešení vypíše za každý test
jeden znak značící, jestli test prošel/neprošel, popř. jaký byl jeho
verdikt.

Work in progress. Teď to plevelí výpis self-testů, chtělo by to asi rozlišovat, jestli se testují self-testy, nebo někdo zavolal Písek interaktivně a chce vidět výsledky testů / popř. nějaký command-line switch.