### PR TITLE
Kontrolovat, jestli judge správně řeší whitespace a CRLF

### DIFF
--- a/fixtures/soucet_kasiopea/judge_bad_whitespace.py
+++ b/fixtures/soucet_kasiopea/judge_bad_whitespace.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import os
+
+
+def main():
+    test_input_file = os.getenv("TEST_INPUT")
+    test_output_file = os.getenv("TEST_OUTPUT")
+
+    if test_input_file is None or test_output_file is None:
+        exit(2)
+
+    with open(test_input_file, "r") as fin:
+        with open(test_output_file, "r") as fcorrect:
+            t = int(fin.readline())
+
+            for _ in range(t):
+                a, b = [int(x) for x in fin.readline().split()]
+                c = int(fcorrect.readline())
+
+                contestant = input()
+
+                if contestant.endswith("\r"):
+                    # Looks like we didn't handle Windows line-endings correctly!
+                    contestant += "oops!"
+                contestant = int(contestant)
+
+                assert a + b == c
+
+                if c != contestant:
+                    exit(1)
+
+    exit(0)
+
+
+main()

--- a/fixtures/soucet_kasiopea/judge_py.py
+++ b/fixtures/soucet_kasiopea/judge_py.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import os
+
+
+def main():
+    test_input_file = os.getenv("TEST_INPUT")
+    test_output_file = os.getenv("TEST_OUTPUT")
+
+    if test_input_file is None or test_output_file is None:
+        exit(2)
+
+    with open(test_input_file, "r") as fin:
+        with open(test_output_file, "r") as fcorrect:
+            t = int(fin.readline())
+
+            for _ in range(t):
+                a, b = [int(x) for x in fin.readline().split()]
+                c = int(fcorrect.readline())
+
+                contestant = int(input())
+
+                assert a + b == c
+
+                if c != contestant:
+                    exit(1)
+
+    exit(0)
+
+
+main()

--- a/pisek/self_tests/test_kasiopea.py
+++ b/pisek/self_tests/test_kasiopea.py
@@ -127,6 +127,18 @@ class TestJudge(TestSoucetKasiopea):
         modify_config(self.task_dir, modification_fn)
 
 
+class TestPythonJudge(TestSoucetKasiopea):
+    def expecting_success(self):
+        return True
+
+    def modify_task(self):
+        def modification_fn(raw_config):
+            raw_config["tests"]["out_check"] = "judge"
+            raw_config["tests"]["out_judge"] = "judge_py"
+
+        modify_config(self.task_dir, modification_fn)
+
+
 class TestBadJudge(TestSoucetKasiopea):
     def expecting_success(self):
         return False
@@ -135,6 +147,18 @@ class TestBadJudge(TestSoucetKasiopea):
         def modification_fn(raw_config):
             raw_config["tests"]["out_check"] = "judge"
             raw_config["tests"]["out_judge"] = "judge_bad"
+
+        modify_config(self.task_dir, modification_fn)
+
+
+class TestBadWhitespaceJudge(TestSoucetKasiopea):
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        def modification_fn(raw_config):
+            raw_config["tests"]["out_check"] = "judge"
+            raw_config["tests"]["out_judge"] = "judge_bad_whitespace"
 
         modify_config(self.task_dir, modification_fn)
 


### PR DESCRIPTION
Metoda: přidat mezery a změnit `\n -> \r\n` v řešení účastníka a vzorovém výstupu. Judge by měl i po těchto úpravách mít stejný verdikt.