### PR TITLE
Vylepšit podporu pro Kasiopeu

### DIFF
--- a/pisek/compile.py
+++ b/pisek/compile.py
@@ -95,10 +95,26 @@ class CCompileRules(CompileRules):
         return result_filepath if gcc.returncode == 0 else None
 
 
+class PascalCompileRules(CompileRules):
+    def __init__(self, supported_extensions: List[str]) -> None:
+        super().__init__(supported_extensions)
+
+    def compile(self, filepath: str, dry_run: bool = True) -> Optional[str]:
+        dirname, filename, _ = _split_path(filepath)
+        build_dir = util.get_build_dir(dirname)
+        result_filepath = os.path.join(build_dir, filename)
+        if dry_run:
+            return result_filepath
+
+        pas_flags = ["-gl", "-O3", "-Sg", "-FE" + build_dir]
+        fpc = subprocess.run(["fpc"] + pas_flags + [filepath])
+        return result_filepath if fpc.returncode == 0 else None
+
 COMPILE_RULES: List[CompileRules] = [
     PythonCompileRules([".py"]),
     CPPCompileRules([".cpp", ".cc"]),
     CCompileRules([".c"]),
+    PascalCompileRules([".pas"]),
 ]
 
 

--- a/pisek/compile.py
+++ b/pisek/compile.py
@@ -110,6 +110,7 @@ class PascalCompileRules(CompileRules):
         fpc = subprocess.run(["fpc"] + pas_flags + [filepath])
         return result_filepath if fpc.returncode == 0 else None
 
+
 COMPILE_RULES: List[CompileRules] = [
     PythonCompileRules([".py"]),
     CPPCompileRules([".cpp", ".cc"]),

--- a/pisek/compile.py
+++ b/pisek/compile.py
@@ -74,7 +74,7 @@ class CPPCompileRules(CompileRules):
         if dry_run:
             return result_filepath
 
-        cpp_flags = ["-std=c++14", "-O2", "-Wall", "-Wshadow"]
+        cpp_flags = ["-std=c++14", "-O2", "-Wall", "-lm", "-Wshadow"]
         gpp = subprocess.run(["g++", filepath, "-o", result_filepath] + cpp_flags)
         return result_filepath if gpp.returncode == 0 else None
 
@@ -90,7 +90,7 @@ class CCompileRules(CompileRules):
         if dry_run:
             return result_filepath
 
-        c_flags = ["-std=c11", "-O2", "-Wall", "-Wshadow"]
+        c_flags = ["-std=c11", "-O2", "-Wall", "-lm", "-Wshadow"]
         gcc = subprocess.run(["gcc", filepath, "-o", result_filepath] + c_flags)
         return result_filepath if gcc.returncode == 0 else None
 


### PR DESCRIPTION
Vzhledem k migraci úloh Kasiopei na nový web jsem objevil a opravil pár nedostatků v úlohách.

* Nastavil jsem, že se standardně pro C/C++ linkuje `-lm` (`<cmath>`/`math.h`)
* Přidal jsem podporu pro úlohy psané v Free Pascalu -- umíme je nyní zkompilovat.

U druhého bodu bychom ale měli zvážit issue https://github.com/kasiopea-org/pisek/issues/52.

