### PR TITLE
Podpora pro checkery

### DIFF
--- a/fixtures/soucet_cms/check.py
+++ b/fixtures/soucet_cms/check.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Checker based on Kasiopea's checker template from Pali Madaj.
+import sys
+import argparse
+
+
+def main(diff):
+    BOUNDS = [(0, 1e9), (-1e9, 1e9), (-1e18, 1e18)]
+    read_values(2, *BOUNDS[diff])
+
+
+# ----------------- Cast nize jsou pomocne funkce, snad nebude treba upravovat -----------------
+
+line_number = 0
+
+
+def read_line():
+    global line_number
+    line_number += 1
+    return input()
+
+
+def fail(message):
+    global line_number
+    print(message + " (na radku {})".format(line_number), file=sys.stderr)
+    sys.exit(1)
+
+
+def read_values(count=None, minimum=None, maximum=None, value_type=int):
+    try:
+        line = read_line()
+    except EOFError:
+        fail("Konec souboru.")
+
+    try:
+        numbers = list(map(value_type, line.split(" ")))
+    except ValueError:
+        fail("Hodnota neni typu {}.".format(value_type))
+
+    if count is not None and len(numbers) != count:
+        fail("Pocet hodnot na radku byl {} a mel byt {}.".format(len(numbers), count))
+    if minimum is not None and any(x < minimum for x in numbers):
+        fail("Nejaka hodnota na radku byla mensi nez {}.".format(minimum))
+    if maximum is not None and any(x > maximum for x in numbers):
+        fail("Nejaka hodnota na radku byla vetsi nez {}.".format(maximum))
+
+    return numbers
+
+
+def expect_eof():
+    koniec = False
+    try:
+        input()
+    except EOFError:
+        koniec = True
+    if not koniec:
+        fail("Soubor pokracuje, ale mel uz skoncit.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Nacte ze stdin vstupy ulohy a zkontroluje jejich spravnost"
+    )
+    parser.add_argument("subtask", type=int, help="subtask (indexovany od 1)")
+    args = parser.parse_args()
+    main(args.subtask - 1)
+    expect_eof()

--- a/fixtures/soucet_cms/check_loose.py
+++ b/fixtures/soucet_cms/check_loose.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import argparse
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Nacte ze stdin vstupy ulohy a zkontroluje jejich spravnost"
+    )
+    parser.add_argument("subtask", type=int, help="subtask (indexovany od 1)")
+    args = parser.parse_args()
+
+    # Does not do any actual checking.

--- a/fixtures/soucet_cms/check_strict.py
+++ b/fixtures/soucet_cms/check_strict.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Checker based on Kasiopea's checker template from Pali Madaj.
+import sys
+import argparse
+
+
+def main(diff):
+    # Here BOUNDS[2] are stricter than what the generator really creates.
+    BOUNDS = [(0, 1e9), (-1e9, 1e9), (-1e9, 1e9)]
+    read_values(2, *BOUNDS[diff])
+
+
+# ----------------- Cast nize jsou pomocne funkce, snad nebude treba upravovat -----------------
+
+line_number = 0
+
+
+def read_line():
+    global line_number
+    line_number += 1
+    return input()
+
+
+def fail(message):
+    global line_number
+    print(message + " (na radku {})".format(line_number), file=sys.stderr)
+    sys.exit(1)
+
+
+def read_values(count=None, minimum=None, maximum=None, value_type=int):
+    try:
+        line = read_line()
+    except EOFError:
+        fail("Konec souboru.")
+
+    try:
+        numbers = list(map(value_type, line.split(" ")))
+    except ValueError:
+        fail("Hodnota neni typu {}.".format(value_type))
+
+    if count is not None and len(numbers) != count:
+        fail("Pocet hodnot na radku byl {} a mel byt {}.".format(len(numbers), count))
+    if minimum is not None and any(x < minimum for x in numbers):
+        fail("Nejaka hodnota na radku byla mensi nez {}.".format(minimum))
+    if maximum is not None and any(x > maximum for x in numbers):
+        fail("Nejaka hodnota na radku byla vetsi nez {}.".format(maximum))
+
+    return numbers
+
+
+def expect_eof():
+    koniec = False
+    try:
+        input()
+    except EOFError:
+        koniec = True
+    if not koniec:
+        fail("Soubor pokracuje, ale mel uz skoncit.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Nacte ze stdin vstupy ulohy a zkontroluje jejich spravnost"
+    )
+    parser.add_argument("subtask", type=int, help="subtask (indexovany od 1)")
+    args = parser.parse_args()
+    main(args.subtask - 1)
+    expect_eof()

--- a/fixtures/soucet_cms/config
+++ b/fixtures/soucet_cms/config
@@ -13,6 +13,8 @@ in_mode=build
 # generator source file
 in_gen=gen
 
+checker=check
+
 out_format=text
 online_validity=360
 out_check=judge

--- a/fixtures/soucet_kasiopea/check.py
+++ b/fixtures/soucet_kasiopea/check.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Checker based on Kasiopea's checker template from Pali Madaj.
+import sys
+import argparse
+
+
+def main(diff):
+    BOUNDS = [(-1e9, 1e9), (-1e18, 1e18)]
+
+    t = read_values(1)[0]
+    for ti in range(t):
+        read_values(2, *BOUNDS[diff])
+
+
+# ----------------- Cast nize jsou pomocne funkce, snad nebude treba upravovat -----------------
+
+line_number = 0
+
+
+def read_line():
+    global line_number
+    line_number += 1
+    return input()
+
+
+def fail(message):
+    global line_number
+    print(message + " (na radku {})".format(line_number), file=sys.stderr)
+    sys.exit(1)
+
+
+def read_values(count=None, minimum=None, maximum=None, value_type=int):
+    try:
+        line = read_line()
+    except EOFError:
+        fail("Konec souboru.")
+
+    try:
+        numbers = list(map(value_type, line.split(" ")))
+    except ValueError:
+        fail("Hodnota neni typu {}.".format(value_type))
+
+    if count is not None and len(numbers) != count:
+        fail("Pocet hodnot na radku byl {} a mel byt {}.".format(len(numbers), count))
+    if minimum is not None and any(x < minimum for x in numbers):
+        fail("Nejaka hodnota na radku byla mensi nez {}.".format(minimum))
+    if maximum is not None and any(x > maximum for x in numbers):
+        fail("Nejaka hodnota na radku byla vetsi nez {}.".format(maximum))
+
+    return numbers
+
+
+def expect_eof():
+    koniec = False
+    try:
+        input()
+    except EOFError:
+        koniec = True
+    if not koniec:
+        fail("Soubor pokracuje, ale mel uz skoncit.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Nacte ze stdin vstupy ulohy a zkontroluje jejich spravnost"
+    )
+    parser.add_argument("subtask", type=int, help="subtask (indexovany od 1)")
+    args = parser.parse_args()
+    main(args.subtask - 1)
+    expect_eof()

--- a/fixtures/soucet_kasiopea/check_loose.py
+++ b/fixtures/soucet_kasiopea/check_loose.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import argparse
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Nacte ze stdin vstupy ulohy a zkontroluje jejich spravnost"
+    )
+    parser.add_argument("subtask", type=int, help="subtask (indexovany od 1)")
+    args = parser.parse_args()
+
+    # Does not do any actual checking.

--- a/fixtures/soucet_kasiopea/check_strict.py
+++ b/fixtures/soucet_kasiopea/check_strict.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Checker based on Kasiopea's checker template from Pali Madaj.
+import sys
+import argparse
+
+
+def main(diff):
+    # Here BOUNDS[2] are stricter than what the generator really creates.
+    BOUNDS = [(-1e9, 1e9), (-1e9, 1e9)]
+
+    t = read_values(1)[0]
+    for ti in range(t):
+        read_values(2, *BOUNDS[diff])
+
+
+# ----------------- Cast nize jsou pomocne funkce, snad nebude treba upravovat -----------------
+
+line_number = 0
+
+
+def read_line():
+    global line_number
+    line_number += 1
+    return input()
+
+
+def fail(message):
+    global line_number
+    print(message + " (na radku {})".format(line_number), file=sys.stderr)
+    sys.exit(1)
+
+
+def read_values(count=None, minimum=None, maximum=None, value_type=int):
+    try:
+        line = read_line()
+    except EOFError:
+        fail("Konec souboru.")
+
+    try:
+        numbers = list(map(value_type, line.split(" ")))
+    except ValueError:
+        fail("Hodnota neni typu {}.".format(value_type))
+
+    if count is not None and len(numbers) != count:
+        fail("Pocet hodnot na radku byl {} a mel byt {}.".format(len(numbers), count))
+    if minimum is not None and any(x < minimum for x in numbers):
+        fail("Nejaka hodnota na radku byla mensi nez {}.".format(minimum))
+    if maximum is not None and any(x > maximum for x in numbers):
+        fail("Nejaka hodnota na radku byla vetsi nez {}.".format(maximum))
+
+    return numbers
+
+
+def expect_eof():
+    koniec = False
+    try:
+        input()
+    except EOFError:
+        koniec = True
+    if not koniec:
+        fail("Soubor pokracuje, ale mel uz skoncit.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Nacte ze stdin vstupy ulohy a zkontroluje jejich spravnost"
+    )
+    parser.add_argument("subtask", type=int, help="subtask (indexovany od 1)")
+    args = parser.parse_args()
+    main(args.subtask - 1)
+    expect_eof()

--- a/fixtures/soucet_kasiopea/config
+++ b/fixtures/soucet_kasiopea/config
@@ -14,6 +14,7 @@ solutions=solve solve_4b solve_slow_4b solve_0b
 [tests]
 in_mode=online
 in_gen=gen
+checker=check
 out_mode=solve
 out_format=text
 online_validity=360

--- a/pisek/checker.py
+++ b/pisek/checker.py
@@ -17,6 +17,11 @@ class Checker(program.Program):
         The subtask number `subtask` is expected to be zero-indexed.
         """
         with open(os.path.join(self.task_config.get_data_dir(), input_file)) as f:
-            res = self.run_raw([str(subtask + 1)], stdin=f, capture_output=True)
+            res = self.run_raw(
+                [str(subtask + 1)],
+                stdin=f,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
 
         return res

--- a/pisek/checker.py
+++ b/pisek/checker.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+
+from . import program
+from .task_config import TaskConfig
+
+
+class Checker(program.Program):
+    def __init__(self, task_config: TaskConfig):
+        assert task_config.checker
+        super().__init__(task_config.task_dir, task_config.checker)
+        self.task_config = task_config
+
+    def run_on_file(self, input_file: str, subtask: int) -> subprocess.CompletedProcess:
+        """
+        Runs the checker on the given file, assuming it is from a specific subtask.
+        The subtask number `subtask` is expected to be zero-indexed.
+        """
+        with open(os.path.join(self.task_config.get_data_dir(), input_file)) as f:
+            res = self.run_raw([str(subtask + 1)], stdin=f, capture_output=True)
+
+        return res

--- a/pisek/self_tests/test_cms.py
+++ b/pisek/self_tests/test_cms.py
@@ -62,5 +62,25 @@ class TestInvalidJudgeScore(TestSoucetCMS):
         overwrite_file(self.task_dir, "judge.cpp", "judge_invalid_score.cpp")
 
 
+class TestLooseChecker(TestSoucetCMS):
+    """ A checker that cannot distinguish between subtasks. """
+
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        overwrite_file(self.task_dir, "check.py", "check_loose.py")
+
+
+class TestStrictChecker(TestSoucetCMS):
+    """ A checker whose bounds are stricter than what the generator creates. """
+
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        overwrite_file(self.task_dir, "check.py", "check_strict.py")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pisek/self_tests/test_kasiopea.py
+++ b/pisek/self_tests/test_kasiopea.py
@@ -182,5 +182,25 @@ class TestPythonCRLF(TestSoucetKasiopea):
             f.write("\r\n".join(new_program))
 
 
+class TestLooseChecker(TestSoucetKasiopea):
+    """ A checker that cannot distinguish between subtasks. """
+
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        overwrite_file(self.task_dir, "check.py", "check_loose.py")
+
+
+class TestStrictChecker(TestSoucetKasiopea):
+    """ A checker whose bounds are stricter than what the generator creates. """
+
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        overwrite_file(self.task_dir, "check.py", "check_strict.py")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pisek/task_config.py
+++ b/pisek/task_config.py
@@ -23,7 +23,7 @@ class TaskConfig:
             self.solutions: List[str] = config["task"]["solutions"].split()
             self.contest_type = config["task"].get("contest_type", "kasiopea")
             self.generator: str = config["tests"]["in_gen"]
-            self.checker: str = config["tests"].get("checker")
+            self.checker: Optional[str] = config["tests"].get("checker")
             self.judge_type: str = config["tests"].get("out_check", "diff")
             self.judge_name: Optional[str] = None
             if self.judge_type == "judge":

--- a/pisek/task_config.py
+++ b/pisek/task_config.py
@@ -28,7 +28,6 @@ class TaskConfig:
             self.judge_name: Optional[str] = None
             if self.judge_type == "judge":
                 self.judge_name = config["tests"]["out_judge"]
-            self.checker: Optional[str] = config["tests"].get("checker")
 
             # Warning: these timeouts are currently ignored in Kasiopea!
             self.timeout_model_solution: Optional[float] = apply_to_optional(

--- a/pisek/task_config.py
+++ b/pisek/task_config.py
@@ -23,6 +23,7 @@ class TaskConfig:
             self.solutions: List[str] = config["task"]["solutions"].split()
             self.contest_type = config["task"].get("contest_type", "kasiopea")
             self.generator: str = config["tests"]["in_gen"]
+            self.checker: str = config["tests"].get("checker")
             self.judge_type: str = config["tests"].get("out_check", "diff")
             self.judge_name: Optional[str] = None
             if self.judge_type == "judge":
@@ -72,9 +73,6 @@ class TaskConfig:
 
     def get_samples_dir(self):
         return os.path.join(self.task_dir, self.samples_subdir)
-
-    def get_solutions_dir(self):
-        return os.path.join(self.task_dir, self.solutions_subdir)
 
 
 class SubtaskConfig:

--- a/pisek/tests/cms_test_suite.py
+++ b/pisek/tests/cms_test_suite.py
@@ -91,7 +91,10 @@ def cms_test_suite(
 
     generator = OfflineGenerator(task_dir, config.generator)
     suite.addTest(GeneratorWorks(config, generator))
-    suite.addTest(test_case.InputsPassChecker(config, in_self_test))
+
+    test_case.add_checker_cases(
+        config, suite, in_self_test, get_subtasks=lambda: get_subtasks(config)
+    )
 
     if solutions is None:
         solutions = config.solutions

--- a/pisek/tests/cms_test_suite.py
+++ b/pisek/tests/cms_test_suite.py
@@ -95,6 +95,7 @@ def cms_test_suite(
 
     generator = OfflineGenerator(task_dir, config.generator)
     suite.addTest(GeneratorWorks(config, generator))
+    suite.addTest(test_case.InputsPassChecker(config, in_self_test))
 
     if solutions is None:
         solutions = config.solutions

--- a/pisek/tests/kasiopea_test_suite.py
+++ b/pisek/tests/kasiopea_test_suite.py
@@ -279,6 +279,10 @@ def kasiopea_test_suite(
     suite.addTest(GeneratesInputs(config, generator, seeds, in_self_test))
     suite.addTest(JudgeHandlesWhitespace(config))
 
+    test_case.add_checker_cases(
+        config, suite, in_self_test, get_subtasks=lambda: get_subtasks(seeds)
+    )
+
     solutions = solutions or config.solutions
 
     # Having an empty `solutions` might be desirable if we only want to test the generator

--- a/pisek/tests/test_case.py
+++ b/pisek/tests/test_case.py
@@ -5,6 +5,8 @@ import unittest
 import shutil
 from typing import List, Tuple, Optional, Callable
 
+import termcolor
+
 from ..checker import Checker
 from ..program import RunResult
 from ..task_config import TaskConfig
@@ -293,14 +295,18 @@ class CheckerDistinguishesSubtasks(TestCase):
             self.assertTrue(
                 failed,
                 (
-                    f"Checker '{self.checker.name}' nedokáže odlišit vstupy "
-                    f"subtasků {subtask_i} a {subtask_i + 1} "
-                    f"(nestěžuje si, když přidáme vstupy ze subtasku {subtask_i + 1}"
-                    f" do subtasku {subtask_i})"
+                    f"Checker '{self.checker.name}' není dost přísný: "
+                    f"nestěžuje si, když přidáme vstupy ze subtasku {subtask_i + 1}"
+                    f" do subtasku {subtask_i}. Subtask {subtask_i} má přitom přísnější "
+                    f"omezení, takže vstupy ze subtasku {subtask_i + 1} by neměly být "
+                    f"platné pro subtask {subtask_i}."
                 ),
             )
 
             last_inputs = set(subtask.inputs)
+
+    def __str__(self):
+        return f"Checker {self.checker.name} rozliší subtasky"
 
 
 class InputsPassChecker(TestCase):
@@ -332,6 +338,9 @@ class InputsPassChecker(TestCase):
                     ),
                 )
 
+    def __str__(self):
+        return f"Vygenerované vstupy projdou checkerem {self.checker.name}"
+
 
 def add_checker_cases(
     task_config: TaskConfig,
@@ -342,9 +351,12 @@ def add_checker_cases(
     if not task_config.checker:
         if not in_self_test:
             print(
-                "\nUpozornění: v configu není specifikovaný checker. "
-                "Vygenerované vstupy tudíž nejsou zkontrolované. "
-                "Doporučujeme proto nastavit v sekci [tasks] pole `checker`.",
+                termcolor.colored(
+                    "Upozornění: v configu není specifikovaný checker. "
+                    "Vygenerované vstupy tudíž nejsou zkontrolované. "
+                    "Doporučujeme proto nastavit v sekci [tests] pole `checker`.",
+                    color="cyan",
+                ),
                 file=sys.stderr,
             )
     else:

--- a/pisek/tests/test_case.py
+++ b/pisek/tests/test_case.py
@@ -246,3 +246,21 @@ class SolutionWorks(SolutionTestCase):
     def log(self, msg, *args, **kwargs):
         if not self.in_self_test:
             super().log(msg, *args, **kwargs)
+
+
+class InputsPassChecker(TestCase):
+    """ If a checker program is specified in the task config, runs the checker """
+
+    def __init__(self, task_config, get_subtasks: Callable[[], List[Subtask]], in_self_test=False):
+        super().__init__(task_config)
+        self.in_self_test = in_self_test
+
+    def runTest(self):
+        if not self.task_config.checker:
+            if not self.in_self_test:
+                self.log(
+                    "\nUpozornění: v configu není specifikovaný checker. "
+                    "Vygenerované vstupy tudíž nejsou zkontrolované. "
+                    "Doporučujeme proto nastavit v sekci [tasks] pole `checker`."
+                )
+            return

--- a/pisek/tests/test_case.py
+++ b/pisek/tests/test_case.py
@@ -5,6 +5,7 @@ import unittest
 import shutil
 from typing import List, Tuple, Optional, Callable
 
+from ..checker import Checker
 from ..program import RunResult
 from ..task_config import TaskConfig
 from ..solution import Solution
@@ -255,19 +256,98 @@ class SolutionWorks(SolutionTestCase):
             super().log(msg, *args, **kwargs)
 
 
-class InputsPassChecker(TestCase):
-    """ If a checker program is specified in the task config, runs the checker """
+class CheckerDistinguishesSubtasks(TestCase):
+    """
+    Makes sure the checker gives different results for different subtasks.
+    Specifically, for subtask i, runs the checker on the inputs for subtask i but tells
+    it that the subtask is (i-1).
+    The check should therefore not pass for at least one of the inputs.
+    """
 
-    def __init__(self, task_config, get_subtasks: Callable[[], List[Subtask]], in_self_test=False):
+    def __init__(
+        self, task_config, checker: Checker, get_subtasks: Callable[[], List[Subtask]]
+    ):
         super().__init__(task_config)
-        self.in_self_test = in_self_test
+        self.checker = checker
+        self.get_subtasks = get_subtasks
 
     def runTest(self):
-        if not self.task_config.checker:
-            if not self.in_self_test:
-                self.log(
-                    "\nUpozornění: v configu není specifikovaný checker. "
-                    "Vygenerované vstupy tudíž nejsou zkontrolované. "
-                    "Doporučujeme proto nastavit v sekci [tasks] pole `checker`."
+        subtasks = self.get_subtasks()
+        last_inputs = set()
+
+        for subtask_i, subtask in enumerate(subtasks):
+            new_inputs = set(subtask.inputs) - last_inputs
+
+            if subtask_i == 0:
+                # Nothing to compare with at this point.
+                continue
+
+            failed = False
+
+            for input_file in new_inputs:
+                res = self.checker.run_on_file(input_file, subtask_i - 1)
+
+                if res.returncode != 0:
+                    failed = True
+
+            self.assertTrue(
+                failed,
+                (
+                    f"Checker '{self.checker.name}' nedokáže odlišit vstupy "
+                    f"subtasků {subtask_i} a {subtask_i + 1} "
+                    f"(nestěžuje si, když přidáme vstupy ze subtasku {subtask_i + 1}"
+                    f" do subtasku {subtask_i})"
+                ),
+            )
+
+            last_inputs = set(subtask.inputs)
+
+
+class InputsPassChecker(TestCase):
+    """ If a checker program is specified in the task config, runs the checker. """
+
+    def __init__(
+        self,
+        task_config,
+        checker: Checker,
+        get_subtasks: Callable[[], List[Subtask]],
+    ):
+        super().__init__(task_config)
+        self.checker = checker
+        self.get_subtasks = get_subtasks
+
+    def runTest(self):
+        subtasks = self.get_subtasks()
+
+        for subtask_i, subtask in enumerate(subtasks):
+            for input_file in subtask.inputs:
+                res = self.checker.run_on_file(input_file, subtask_i)
+
+                self.assertEqual(
+                    res.returncode,
+                    0,
+                    (
+                        f"Checker '{self.checker.name}' neprošel pro vstup {input_file} "
+                        f"subtasku {subtask_i + 1}.\n{util.quote_process_output(res)}"
+                    ),
                 )
-            return
+
+
+def add_checker_cases(
+    task_config: TaskConfig,
+    suite: unittest.TestSuite,
+    in_self_test,
+    get_subtasks,
+):
+    if not task_config.checker:
+        if not in_self_test:
+            print(
+                "\nUpozornění: v configu není specifikovaný checker. "
+                "Vygenerované vstupy tudíž nejsou zkontrolované. "
+                "Doporučujeme proto nastavit v sekci [tasks] pole `checker`.",
+                file=sys.stderr,
+            )
+    else:
+        checker = Checker(task_config)
+        suite.addTest(CheckerDistinguishesSubtasks(task_config, checker, get_subtasks))
+        suite.addTest(InputsPassChecker(task_config, checker, get_subtasks))


### PR DESCRIPTION
Dva nové testy pro checkery:

- `InputsPassChecker` spustí checker na vygenerované vstupy a zkontroluje, že projde.
- `CheckerDistinguishesSubtasks` je tu proto, aby neprošel checker, který vždycky vrátí returncode 0. Zkontroluje, že kdybychom do subtasku `i` přidali testy ze subtasku `i+1`, checker si bude stěžovat.

Taky jsem přidal odpovídající self-testy, jak pro Kasiopeu tak pro CMS.

Do budoucna bych zvážil, jestli `get_subtasks` nedát do `TaskConfigu` a `in_self_tests` taky.

Resolves #5