### PR TITLE
Vracet cachované .out soubory vytvořené řešeními

### DIFF
--- a/pisek/generator.py
+++ b/pisek/generator.py
@@ -87,6 +87,9 @@ class OfflineGenerator(Program):
             self.cache_used = True
             return 0
 
+        # Get rid of old inputs/outputs that would be invalidated now
+        util.clean_data_dir(self.task_config)
+
         popen = subprocess.Popen(
             [self.executable, test_dir],
             stdout=subprocess.PIPE,

--- a/pisek/self_tests/test_cms.py
+++ b/pisek/self_tests/test_cms.py
@@ -4,7 +4,7 @@ import shutil
 import unittest
 
 from pisek.self_tests.util import TestFixtureVariant, overwrite_file
-from pisek import util
+from pisek.task_config import TaskConfig
 
 
 class TestSoucetCMS(TestFixtureVariant):
@@ -34,6 +34,30 @@ class TestMissingInputFilesForSubtask(TestSoucetCMS):
 
     def modify_task(self):
         overwrite_file(self.task_dir, "gen.py", "gen_incomplete.py")
+
+
+class TestOldInputsDeleted(TestSoucetCMS):
+    """ Do we get rid of out-of-date inputs? """
+
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        task_config = TaskConfig(self.task_dir)
+        self.data_dir = task_config.get_data_dir()
+
+        # We only care about the generation part, so remove solve.py to stop the tests
+        # right after the generator finishes.
+        os.remove(os.path.join(self.task_dir, "solve.py"))
+
+        os.makedirs(self.data_dir, exist_ok=True)
+
+        with open(os.path.join(self.data_dir, "01_outdated.in"), "w") as f:
+            # This old input does not conform to the subtask! Get rid of it.
+            f.write("-3 -2\n")
+
+    def check_end_state(self):
+        self.assertNotIn("01_outdated.in", os.listdir(self.data_dir))
 
 
 class TestScoreCounting(TestSoucetCMS):

--- a/pisek/self_tests/util.py
+++ b/pisek/self_tests/util.py
@@ -69,6 +69,13 @@ class TestFixtureVariant(unittest.TestCase):
             + "\nVýstup testu:\n{}".format(out),
         )
 
+        self.check_end_state()
+
+    def check_end_state(self):
+        # Here we can verify whether some conditions hold when Pisek finishes,
+        # making sure that the end state is reasonable
+        pass
+
     def tearDown(self):
         if not self.fixture_path():
             return

--- a/pisek/solution.py
+++ b/pisek/solution.py
@@ -20,6 +20,15 @@ class Solution(program.Program):
         self.compile_if_needed()
         assert self.executable is not None
 
+        if (
+            output_file
+            and util.file_is_newer(output_file, self.executable)
+            and util.file_is_newer(output_file, input_file)
+        ):
+            # The output file is newer than both the executable and the input,
+            # so it should be up-to-date.
+            return program.RunResult.OK, output_file
+
         res = program.run(self.executable, input_file, output_file, timeout)
 
         if res == program.RunResult.OK:

--- a/pisek/solution.py
+++ b/pisek/solution.py
@@ -28,6 +28,9 @@ class Solution(program.Program):
             # The output file is newer than both the executable and the input,
             # so it should be up-to-date.
             return program.RunResult.OK, output_file
+            # TODO: with the above, a solution that ends with a runtime error and is
+            #   re-run will wrongly get a 'Wrong Answer' verdict next time, instead of
+            #   'Runtime Error'. Can we fix this somehow?
 
         res = program.run(self.executable, input_file, output_file, timeout)
 

--- a/pisek/tests/cms_test_suite.py
+++ b/pisek/tests/cms_test_suite.py
@@ -56,10 +56,6 @@ class GeneratorWorks(test_case.GeneratorTestCase):
         if self.generator.cache_used:
             message = "\n  Generátor se nezměnil, používám vstupy vygenerované v předchozím běhu."
             print(termcolor.colored(message, color="cyan"))
-        else:
-            # Remove old solution outputs. The invalidated cache would not be used either
-            # way, but this way we get rid of possible junk
-            util.clean_data_dir(self.task_config, leave_inputs=True)
 
     def __str__(self):
         return f"Generátor {self.generator.name} funguje"

--- a/pisek/tests/cms_test_suite.py
+++ b/pisek/tests/cms_test_suite.py
@@ -56,6 +56,10 @@ class GeneratorWorks(test_case.GeneratorTestCase):
         if self.generator.cache_used:
             message = "\n  Generátor se nezměnil, používám vstupy vygenerované v předchozím běhu."
             print(termcolor.colored(message, color="cyan"))
+        else:
+            # Remove old solution outputs. The invalidated cache would not be used either
+            # way, but this way we get rid of possible junk
+            util.clean_data_dir(self.task_config, leave_inputs=True)
 
     def __str__(self):
         return f"Generátor {self.generator.name} funguje"
@@ -75,7 +79,6 @@ def cms_test_suite(
     """
 
     config = TaskConfig(task_dir)
-    util.clean_data_dir(config, leave_inputs=True)
 
     if timeout is None:
         timeout = config.timeout_other_solutions or util.DEFAULT_TIMEOUT

--- a/pisek/tests/kasiopea_test_suite.py
+++ b/pisek/tests/kasiopea_test_suite.py
@@ -194,6 +194,10 @@ class GeneratesInputs(test_case.GeneratorTestCase):
         if self.generator.cache_used:
             message = "\n  Generátor se nezměnil, používám vstupy vygenerované v předchozím běhu."
             print(termcolor.colored(message, color="cyan"))
+        else:
+            # Remove old solution outputs. The invalidated cache would not be used either
+            # way, but this way we get rid of possible junk
+            util.clean_data_dir(self.task_config, leave_inputs=True)
 
     def __str__(self):
         return f"Generátor {self.generator.name} vygeneruje vstupy"
@@ -264,7 +268,6 @@ def kasiopea_test_suite(
     that they get the expected number of points.
     """
     config = TaskConfig(task_dir)
-    util.clean_data_dir(config, leave_inputs=True)
 
     suite = unittest.TestSuite()
 

--- a/pisek/tests/test_case.py
+++ b/pisek/tests/test_case.py
@@ -103,8 +103,6 @@ class SolutionWorks(SolutionTestCase):
         # pass a function to get them later
         self.get_subtasks = get_subtasks
 
-        self.results_cache: Dict[str, Tuple[float, Verdict]] = {}
-
     def test_passes_samples(self):
         samples_dir = self.task_config.get_samples_dir()
         data_dir = self.task_config.get_data_dir()
@@ -182,23 +180,17 @@ class SolutionWorks(SolutionTestCase):
             assert len(model_outputs) == len(inputs)
 
         for input_filename, model_output_filename in zip(inputs, model_outputs):
-            if input_filename in self.results_cache:
-                from_cache = True
-                pts, verdict = self.results_cache[input_filename]
-            else:
-                from_cache = False
-                pts, verdict = self.judge.evaluate(
-                    self.solution,
-                    input_file=os.path.join(data_dir, input_filename),
-                    correct_output=os.path.join(data_dir, model_output_filename),
-                    run_config=self.run_config,
-                )
-                self.results_cache[input_filename] = pts, verdict
+            pts, verdict = self.judge.evaluate(
+                self.solution,
+                input_file=os.path.join(data_dir, input_filename),
+                correct_output=os.path.join(data_dir, model_output_filename),
+                run_config=self.run_config,
+            )
 
             if verdict.result == RunResult.OK:
                 c = "·" if pts == 1 else "W" if pts == 0 else "P"
 
-                if pts != 1 and not from_cache:
+                if pts != 1:
                     msg = self.create_wrong_answer_message(
                         input_filename, model_output_filename
                     )


### PR DESCRIPTION
Jednoduchá změna, ale _hodně_ zrychluje workflow. Takhle už se bude cachovat vše pomalé, takže po prvním runu trvajícím asi 2 minuty dostaneme při druhém spuštění:

```
Testuji úlohu vyberko/2021/d1/stepan
Upozornění: v configu není specifikovaný checker. Vygenerované vstupy tudíž nejsou zkontrolované. Doporučujeme proto nastavit v sekci [tests] pole `checker`.
Generátor geninputs funguje ...
  Generátor se nezměnil, používám vstupy vygenerované v předchozím běhu.
ok
Řešení solutions/opt získá 10b ... ····|························|············|··············|················| ok
Řešení solutions/wrong_0b získá 0b ... |W|W|W|W| ok
Řešení solutions/hranynulawrong_0b získá 0b ... |····W|W|W|W| ok
Řešení solutions/hranynula_3b získá 3b ... |························|W|W|W| ok
Řešení solutions/ruznafi_rus_2b získá 2b ... |W|W|··············|W| ok
Řešení solutions/kostra_3b získá 3b ... |W|············|W|W| ok
Řešení solutions/vv_ruznafi_2b získá 2b ... |··W|W|··············|W| ok
Řešení solutions/vv získá 10b ... ····|························|············|··············|················| ok

----------------------------------------------------------------------
Ran 9 tests in 0.250s

OK
```

Tahle a předchozí změna je asi trochu laxnější v tom, co se smaže ze starých dat `data_dir` při novém spuštění, ale pro plné čištění je tu pořád `pisek clean`, tak to je snad ok.