### PR TITLE
Vypsat chybovou hlášku při runtime erroru řešení

### DIFF
--- a/.github/workflows/python_pisek_tester.yml
+++ b/.github/workflows/python_pisek_tester.yml
@@ -32,5 +32,4 @@ jobs:
     - name: Check typing
       run: |
         pip install mypy
-        mypy --install-types
         mypy pisek/

--- a/pisek/__main__.py
+++ b/pisek/__main__.py
@@ -4,7 +4,7 @@ import unittest
 import sys
 
 from pisek.tests.util import get_test_suite
-from pisek.program import Program, RunResult
+from pisek.program import Program, RunResultKind
 from pisek import util
 
 
@@ -29,10 +29,10 @@ def run_solution(args, unknown_args):
 
     cwd = os.getcwd()
     sol = Program(cwd, args.solution)
-    result = sol.run(unknown_args)
+    run_result = sol.run(unknown_args)
 
-    if result != RunResult.OK:
-        eprint("Chyba při běhu.")
+    if run_result.kind != RunResultKind.OK:
+        eprint(f"Chyba při běhu: {run_result.msg}")
         exit(1)
 
     return None

--- a/pisek/program.py
+++ b/pisek/program.py
@@ -13,7 +13,7 @@ class RunResultKind(Enum):
     RunResult."""
 
     OK = 0
-    NONZERO_EXIT_CODE = 1
+    RUNTIME_ERROR = 1
     TIMEOUT = 2
 
 
@@ -39,7 +39,7 @@ def completed_process_to_run_result(result: subprocess.CompletedProcess, executa
             error_message += f" s exitcodem {result.returncode}"
 
         return RunResult(
-            RunResultKind.NONZERO_EXIT_CODE,
+            RunResultKind.RUNTIME_ERROR,
             error_message + "\n" + util.quote_process_output(result),
         )
 

--- a/pisek/solution.py
+++ b/pisek/solution.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 
 from . import util
 from . import program
+from .program import RunResultKind
 from .task_config import TaskConfig
 
 
@@ -37,14 +38,14 @@ class Solution(program.Program):
         ):
             # The output file is newer than both the executable and the input,
             # so it should be up-to-date.
-            return program.RunResult.OK, output_file
+            return program.RunResult(RunResultKind.OK), output_file
             # TODO: with the above, a solution that ends with a runtime error and is
             #   re-run will wrongly get a 'Wrong Answer' verdict next time, instead of
             #   'Runtime Error'. Can we fix this somehow?
 
         res = program.run(self.executable, input_file, output_file, timeout)
 
-        if res == program.RunResult.OK:
+        if res.kind == program.RunResultKind.OK:
             return res, output_file
         else:
             # Set the modification time of this file to 1970 so that it is not used

--- a/pisek/tests/kasiopea_test_suite.py
+++ b/pisek/tests/kasiopea_test_suite.py
@@ -2,19 +2,18 @@ import shutil
 import unittest
 import os
 import random
-from typing import Optional, Tuple, Dict, List
+from typing import Optional, List
 
 import tqdm
 import termcolor
 
 from . import test_case
 from .test_case import Subtask, SolutionWorks
-from ..judge import Verdict
 from ..task_config import TaskConfig
 from .. import util
 from ..solution import Solution
 from ..generator import OnlineGenerator
-from ..program import RunResult
+from ..program import RunResultKind
 from .. import judge
 
 
@@ -83,7 +82,7 @@ def generate_outputs(
             for seed in seeds:
                 path = os.path.join(data_dir, util.get_input_name(seed, subtask))
                 result, output_file = solution.run_on_file(path, timeout)
-                if quit_on_timeout and result == RunResult.TIMEOUT:
+                if quit_on_timeout and result == RunResultKind.TIMEOUT:
                     break
 
                 if output_file is not None:
@@ -232,14 +231,16 @@ class JudgeHandlesWhitespace(test_case.TestCase):
         )
         shutil.copy2(sample_out, sample_out_whitespaced)
 
-        result, output_file = self.model_solution.run_on_file(sample_in)
-        self.assertEqual(result, RunResult.OK, "Vzorové řešení selhalo na sample.in")
+        run_result, output_file = self.model_solution.run_on_file(sample_in)
+        self.assertEqual(
+            run_result.kind, RunResultKind.OK, "Vzorové řešení selhalo na sample.in"
+        )
 
         # To be sure, add different amounts of whitespace to each.
         self.add_whitespace(output_file, n_spaces=2)
         self.add_whitespace(sample_out_whitespaced, n_spaces=3)
 
-        score, verdict = self.judge.evaluate_on_file(
+        score, run_result = self.judge.evaluate_on_file(
             sample_in, sample_out_whitespaced, output_file
         )
 

--- a/pisek/tests/test_case.py
+++ b/pisek/tests/test_case.py
@@ -9,10 +9,10 @@ import termcolor
 import tqdm
 
 from ..checker import Checker
-from ..program import RunResult
+from ..program import RunResultKind
 from ..task_config import TaskConfig
 from ..solution import Solution
-from ..judge import make_judge, Judge, Verdict
+from ..judge import make_judge, Judge
 from .. import util
 
 
@@ -181,14 +181,14 @@ class SolutionWorks(SolutionTestCase):
             assert len(model_outputs) == len(inputs)
 
         for input_filename, model_output_filename in zip(inputs, model_outputs):
-            pts, verdict = self.judge.evaluate(
+            pts, run_result = self.judge.evaluate(
                 self.solution,
                 input_file=os.path.join(data_dir, input_filename),
                 correct_output=os.path.join(data_dir, model_output_filename),
                 run_config=self.run_config,
             )
 
-            if verdict.result == RunResult.OK:
+            if run_result.kind == RunResultKind.OK:
                 c = "·" if pts == 1 else "W" if pts == 0 else "P"
 
                 if pts != 1:
@@ -198,11 +198,14 @@ class SolutionWorks(SolutionTestCase):
                     messages.append(msg)
             else:
                 result_chars = {
-                    RunResult.TIMEOUT: "T",
-                    RunResult.NONZERO_EXIT_CODE: "!",
+                    RunResultKind.TIMEOUT: "T",
+                    RunResultKind.NONZERO_EXIT_CODE: "!",
                 }
 
-                c = result_chars[verdict.result]
+                c = result_chars[run_result.kind]
+
+                if run_result.msg is not None:
+                    messages.append(run_result.msg)
 
             self.log(c, end="")
 

--- a/pisek/tests/test_case.py
+++ b/pisek/tests/test_case.py
@@ -199,7 +199,7 @@ class SolutionWorks(SolutionTestCase):
             else:
                 result_chars = {
                     RunResultKind.TIMEOUT: "T",
-                    RunResultKind.NONZERO_EXIT_CODE: "!",
+                    RunResultKind.RUNTIME_ERROR: "!",
                 }
 
                 c = result_chars[run_result.kind]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setuptools.setup(
     version="0.1",
     description="Nástroj na kontrolování úloh",
     packages=setuptools.find_packages(),
-    install_requires=["tqdm>=4.50", "termcolor>=1.1"],
+    install_requires=["tqdm>=4.50", "termcolor>=1.1", "types-termcolor"],
     extras_require={"dev": ["black", "mypy"]},
     entry_points={"console_scripts": ["pisek=pisek.__main__:main_wrapped"]},
 )


### PR DESCRIPTION
Resolves #20 and #44

Enum `RunResult` jsem přejmenoval na `RunResultKind` a `Verdict` na původní `RunResult` - je to prostě `RunResultKind` + optional chybová hláška. `Verdict` bylo beztak trochu matoucí, protože to nemá s judgem nic společného (jak jsem si myslel #44).
Všechny funkce v `program.py` teď vrací nový `RunResult`. Díky tomu lze propagovat chybovou hlášku až k testům a tam ji vypsat.

Ukázka výstupu:

```
Testuji řešení: solve
Běží generátor: 100%|██████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 1569.14it/s]

  Generátor se nezměnil, používám vstupy vygenerované v předchozím běhu.
ok
Judge správně řeší whitespace a konce řádku ... ok
Řešení solve získá 10b ... ·|·|!| FAIL

======================================================================
FAIL: Řešení solve získá 10b
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/vaclav/prog/pisek/pisek/tests/test_case.py", line 253, in runTest
    self.assertEqual(
AssertionError: 4 != 10 : Řešení solve mělo získat 10b, ale získalo 4b.
Program solve skončil kvůli signálu 11 (segmentation fault, přístup mimo povolenou paměť)
stdout: (žádný)
stderr: (žádný)

----------------------------------------------------------------------
Ran 3 tests in 0.219s

FAILED (failures=1)
```