### PR TITLE
sec_solve_time_limit defaultuje na solve_time_limit fixes #76

### DIFF
--- a/example-config
+++ b/example-config
@@ -97,4 +97,4 @@ solve_time_limit=3
 sec_solve_time_limit=4
 # Pouze CMS
 # Časový limit pro ostatní řešení
-# Při neuvedení 6 minut
+# Při neuvedení solve_time_limit

--- a/fixtures/soucet_cms/config
+++ b/fixtures/soucet_cms/config
@@ -34,8 +34,6 @@ points=6
 in_globs=02*.in 03*.in
 
 [limits]
-# Time limit (seconds) for the model solution (first listed)
+# Time limit (seconds) for solutions
 solve_time_limit=2
-# Time limit (seconds) for other solutions
-sec_solve_time_limit=2
 

--- a/pisek/tests/cms_test_suite.py
+++ b/pisek/tests/cms_test_suite.py
@@ -101,7 +101,9 @@ def cms_test_suite(
     config = TaskConfig(task_dir)
 
     if timeout is None:
-        timeout = config.timeout_other_solutions or util.DEFAULT_TIMEOUT
+        timeout = config.timeout_other_solutions or \
+                  config.timeout_model_solution or \
+                  util.DEFAULT_TIMEOUT
 
     timeout_model_solution = config.timeout_model_solution or timeout
 


### PR DESCRIPTION
Nyní ``sec_solve_time_limit`` defaultuje na ``solve_time_limit`` a není to v configu zapotřebí psát dvakrát.