### PR TITLE
Redo paths

### DIFF
--- a/pisek/jobs/jobs.py
+++ b/pisek/jobs/jobs.py
@@ -164,7 +164,7 @@ class Job(PipelineItem, CaptureInitParams):
             else:
                 for dir_, _, dir_files in os.walk(path):
                     for file in dir_files:
-                        expanded_files.append((os.path.join(dir_, file)))
+                        expanded_files.append(os.path.join(dir_, file))
 
         for file in sorted(expanded_files):
             if not os.path.exists(file):

--- a/pisek/jobs/jobs.py
+++ b/pisek/jobs/jobs.py
@@ -26,6 +26,7 @@ import yaml
 import os.path
 from pisek.jobs.cache import Cache, CacheEntry
 from pisek.env import Env
+from pisek.paths import TaskPath
 
 State = Enum("State", ["in_queue", "running", "succeeded", "failed", "canceled"])
 
@@ -136,10 +137,9 @@ class Job(PipelineItem, CaptureInitParams):
         self._terminal_output.append((msg + end, stderr))
         return super()._print(msg, end, stderr)
 
-    def _access_file(self, filename: str) -> None:
+    def _access_file(self, filename: TaskPath) -> None:
         """Add file this job depends on."""
-        filename = os.path.normpath(filename)
-        self._accessed_files.add(filename)
+        self._accessed_files.add(filename.relpath)
 
     def _signature(
         self, envs: AbstractSet[str], files: AbstractSet[str], results: dict[str, Any]

--- a/pisek/jobs/jobs.py
+++ b/pisek/jobs/jobs.py
@@ -157,20 +157,22 @@ class Job(PipelineItem, CaptureInitParams):
             sign.update(f"{variable}={self._env.get_without_log(variable)}\n".encode())
 
         expanded_files = []
-        for path in sorted(files):
+        for file in sorted(files):
+            path = os.path.join(self._env.task_dir, file)
             if os.path.isfile(path):
                 expanded_files.append(path)
             else:
                 for dir_, _, dir_files in os.walk(path):
                     for file in dir_files:
-                        expanded_files.append(os.path.join(dir_, file))
+                        expanded_files.append((os.path.join(dir_, file)))
 
         for file in sorted(expanded_files):
             if not os.path.exists(file):
                 return (None, "File nonexistent")
             with open(file, "rb") as f:
                 file_sign = hashlib.file_digest(f, "sha256")
-            sign.update(f"{file}={file_sign.hexdigest()}\n".encode())
+            relfile = os.path.relpath(file, self._env.task_dir)
+            sign.update(f"{relfile}={file_sign.hexdigest()}\n".encode())
 
         for name, result in sorted(results.items()):
             sign.update(f"{name}={yaml.dump(result)}".encode())

--- a/pisek/jobs/parts/chaos_monkey.py
+++ b/pisek/jobs/parts/chaos_monkey.py
@@ -59,10 +59,12 @@ class Invalidate(TaskJob):
 class Incomplete(Invalidate):
     """Makes an incomplete output."""
 
-    def __init__(self, env: Env, from_file: TaskPath, to_file: TaskPath, seed: int) -> None:
+    def __init__(
+        self, env: Env, from_file: TaskPath, to_file: TaskPath, seed: int
+    ) -> None:
         super().__init__(
             env,
-            f"Incomplete {from_file} -> {to_file} (seed {seed:x})",
+            f"Incomplete {from_file:n} -> {to_file:n} (seed {seed:x})",
             from_file,
             to_file,
             seed,
@@ -85,7 +87,7 @@ class ChaosMonkey(Invalidate):
     def __init__(self, env, from_file: TaskPath, to_file: TaskPath, seed: int) -> None:
         super().__init__(
             env,
-            f"ChaosMonkey {from_file} -> {to_file} (seed {seed:x})",
+            f"ChaosMonkey {from_file:n} -> {to_file:n} (seed {seed:x})",
             from_file,
             to_file,
             seed,

--- a/pisek/jobs/parts/chaos_monkey.py
+++ b/pisek/jobs/parts/chaos_monkey.py
@@ -18,6 +18,7 @@ import random
 import string
 
 from pisek.env import Env
+from pisek.paths import TaskPath
 from pisek.jobs.parts.task_job import TaskJob
 
 
@@ -47,18 +48,18 @@ class Invalidate(TaskJob):
     """Abstract Job for Invalidating an output."""
 
     def __init__(
-        self, env: Env, name: str, from_file: str, to_file: str, seed: int
+        self, env: Env, name: str, from_file: TaskPath, to_file: TaskPath, seed: int
     ) -> None:
         super().__init__(env, name)
         self.seed = seed
-        self.from_file = self._output(from_file)
-        self.to_file = self._invalid_output(to_file)
+        self.from_file = from_file
+        self.to_file = to_file
 
 
 class Incomplete(Invalidate):
     """Makes an incomplete output."""
 
-    def __init__(self, env: Env, from_file: str, to_file: str, seed: int) -> None:
+    def __init__(self, env: Env, from_file: TaskPath, to_file: TaskPath, seed: int) -> None:
         super().__init__(
             env,
             f"Incomplete {from_file} -> {to_file} (seed {seed:x})",
@@ -81,7 +82,7 @@ class Incomplete(Invalidate):
 class ChaosMonkey(Invalidate):
     """Tries to break judge by generating nasty output."""
 
-    def __init__(self, env, from_file: str, to_file: str, seed: int) -> None:
+    def __init__(self, env, from_file: TaskPath, to_file: TaskPath, seed: int) -> None:
         super().__init__(
             env,
             f"ChaosMonkey {from_file} -> {to_file} (seed {seed:x})",

--- a/pisek/jobs/parts/checker.py
+++ b/pisek/jobs/parts/checker.py
@@ -150,7 +150,7 @@ class CheckerJob(ProgramsJob):
         **kwargs,
     ):
         super().__init__(
-            env=env, name=f"Check {input_} on subtask {subtask}", **kwargs
+            env=env, name=f"Check {input_:n} on subtask {subtask}", **kwargs
         )
         self.checker = checker
         self.subtask = subtask
@@ -171,12 +171,12 @@ class CheckerJob(ProgramsJob):
         result = self._check()
         if self.expected == RunResultKind.OK != result.kind:
             raise self._create_program_failure(
-                f"Checker failed on {self.input} (subtask {self.subtask}) but should have succeeded.",
+                f"Checker failed on {self.input:p} (subtask {self.subtask}) but should have succeeded.",
                 result,
             )
         elif self.expected == RunResultKind.RUNTIME_ERROR != result.kind:
             raise self._create_program_failure(
-                f"Checker succeeded on {self.input} (subtask {self.subtask}) but should have failed.",
+                f"Checker succeeded on {self.input:p} (subtask {self.subtask}) but should have failed.",
                 result,
             )
         return result

--- a/pisek/jobs/parts/checker.py
+++ b/pisek/jobs/parts/checker.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 
 from pisek.jobs.jobs import State, Job, PipelineItemFailure
 from pisek.env import Env
+from pisek.paths import TaskPath
 from pisek.task_config import ProgramType
 from pisek.terminal import colored
 from pisek.jobs.parts.task_job import TaskJobManager
@@ -33,8 +34,7 @@ class CheckerManager(TaskJobManager):
         super().__init__("Running checker")
 
     def _get_jobs(self) -> list[Job]:
-        checker = self._env.config.checker
-        if checker is None:
+        if self._env.config.checker is None:
             if self._env.strict:
                 raise PipelineItemFailure("No checker specified in config.")
             else:
@@ -46,7 +46,7 @@ class CheckerManager(TaskJobManager):
                 )
             return []
 
-        checker = self._resolve_path(checker)
+        checker = TaskPath.base_path(self._env, self._env.config.checker)
 
         jobs: list[Job] = [compile := Compile(self._env, checker)]
 
@@ -118,7 +118,7 @@ class LooseCheckJobGroup:
                 return (
                     f"Checker is not strict enough:\n"
                     f"All inputs of subtask {self.num} should have not passed on predecessor subtask {pred}\n"
-                    f"but on input {job.input_name} did not."
+                    f"but on input {job.input} did not."
                 )
             if fail_mode == "any" and RunResultKind.RUNTIME_ERROR not in results:
                 return (
@@ -128,7 +128,7 @@ class LooseCheckJobGroup:
                 )
             if RunResultKind.TIMEOUT in results:
                 to_job = self._index_job(pred, results, RunResultKind.TIMEOUT)
-                return f"Checker timeouted on input {to_job.input_name}, subtask {self.num}."
+                return f"Checker timeouted on input {to_job.input}, subtask {self.num}."
         return None
 
     def _index_job(
@@ -143,20 +143,19 @@ class CheckerJob(ProgramsJob):
     def __init__(
         self,
         env: Env,
-        checker: str,
-        input_name: str,
+        checker: TaskPath,
+        input_: TaskPath,
         subtask: int,
         expected: Optional[RunResultKind],
         **kwargs,
     ):
         super().__init__(
-            env=env, name=f"Check {input_name} on subtask {subtask}", **kwargs
+            env=env, name=f"Check {input_} on subtask {subtask}", **kwargs
         )
         self.checker = checker
         self.subtask = subtask
-        self.input_name = input_name
-        self.input_file = self._input(input_name)
-        self.log_file = self._log_file(input_name, self.checker)
+        self.input = input_
+        self.log_file = TaskPath.log_file(self._env, input_.name, self.checker.name)
         self.expected = expected
 
     def _check(self) -> RunResult:
@@ -164,7 +163,7 @@ class CheckerJob(ProgramsJob):
             ProgramType.checker,
             self.checker,
             args=[str(self.subtask)],
-            stdin=self.input_file,
+            stdin=self.input,
             stderr=self.log_file,
         )
 
@@ -172,12 +171,12 @@ class CheckerJob(ProgramsJob):
         result = self._check()
         if self.expected == RunResultKind.OK != result.kind:
             raise self._create_program_failure(
-                f"Checker failed on {self.input_name} (subtask {self.subtask}) but should have succeeded.",
+                f"Checker failed on {self.input} (subtask {self.subtask}) but should have succeeded.",
                 result,
             )
         elif self.expected == RunResultKind.RUNTIME_ERROR != result.kind:
             raise self._create_program_failure(
-                f"Checker succeeded on {self.input_name} (subtask {self.subtask}) but should have failed.",
+                f"Checker succeeded on {self.input} (subtask {self.subtask}) but should have failed.",
                 result,
             )
         return result

--- a/pisek/jobs/parts/compile.py
+++ b/pisek/jobs/parts/compile.py
@@ -118,7 +118,13 @@ class Compile(ProgramsJob):
 
     def _compile_pas(self, program: TaskPath):
         build_dir = TaskPath.executable_path(self._env, ".")
-        pas_flags = ["-gl", "-O3", "-Sg", "-o" + self.target.fullpath, "-FE" + build_dir.fullpath]
+        pas_flags = [
+            "-gl",
+            "-O3",
+            "-Sg",
+            "-o" + self.target.fullpath,
+            "-FE" + build_dir.fullpath,
+        ]
 
         return self._run_compilation(["fpc"] + pas_flags + [program.fullpath], program)
 
@@ -198,13 +204,13 @@ class Compile(ProgramsJob):
         flags = []
 
         if self.stub is not None:
-            filename = f"{self.stub}.{extension}"
+            filename = TaskPath.base_path(self._env, f"{self.stub:p}.{extension}")
             self._access_file(filename)
-            flags += [filename]
+            flags += [filename.fullpath]
 
         for header in self.headers:
             self._access_file(header)
-            directory = os.path.normpath(os.path.dirname(header))
+            directory = os.path.normpath(os.path.dirname(header.fullpath))
             flags += [f"-I{directory}"]
 
         return flags

--- a/pisek/jobs/parts/compile.py
+++ b/pisek/jobs/parts/compile.py
@@ -19,8 +19,9 @@ import shutil
 import subprocess
 import sys
 
-from pisek.jobs.jobs import State, PipelineItemFailure
 from pisek.env import Env
+from pisek.paths import TaskPath
+from pisek.jobs.jobs import State, PipelineItemFailure
 from pisek.jobs.parts.program import ProgramsJob
 
 
@@ -30,26 +31,27 @@ class Compile(ProgramsJob):
     def __init__(
         self,
         env: Env,
-        program: str,
+        program: TaskPath,
         use_stub: bool = False,
         **kwargs,
     ) -> None:
-        super().__init__(env=env, name=f"Compile {os.path.basename(program)}", **kwargs)
+        super().__init__(env=env, name=f"Compile {program:n}", **kwargs)
         self.program = program
         self.use_stub = use_stub
-        self.target = self._executable(os.path.basename(program))
+        self.target = TaskPath.executable_file(self._env, program.name)
 
         self.stub = None
         self.headers = []
 
         if use_stub and self._env.config.stub:
-            self.stub = self._resolve_path(self._env.config.stub)
+            self.stub = TaskPath.base_path(self._env, self._env.config.stub)
         if use_stub and self._env.config.headers:
             self.headers = [
-                self._resolve_path(header) for header in self._env.config.headers
+                TaskPath.base_path(self._env, header)
+                for header in self._env.config.headers
             ]
 
-    def _resolve_extension(self, name: str) -> str:
+    def _resolve_extension(self, name: TaskPath) -> TaskPath:
         """
         Given `name`, finds a file named `name`.[ext],
         where [ext] is a file extension for one of the supported languages.
@@ -58,56 +60,54 @@ class Compile(ProgramsJob):
         """
         extensions = supported_extensions()
         candidates = []
+        path = name.fullpath
         for ext in extensions:
-            if os.path.isfile(name + ext):
-                candidates.append(name + ext)
-            if name.endswith(ext) and os.path.isfile(name):
+            if os.path.isfile(path + ext):
+                candidates.append(path + ext)
+            if path.endswith(ext) and os.path.isfile(path):
                 # Extension already present in `name`
-                candidates.append(name)
+                candidates.append(path)
 
         if len(candidates) == 0:
-            raise PipelineItemFailure(f"No program with given name exists: {name}")
+            raise PipelineItemFailure(f"No program with given name exists: {path}")
         if len(candidates) > 1:
             raise PipelineItemFailure(
                 f"Multiple programs with same name exist: {', '.join(candidates)}"
             )
 
-        return candidates[0]
+        return TaskPath.from_abspath(self._env, candidates[0])
 
     def _run(self):
         """Compiles program."""
         program = self._resolve_extension(self.program)
-        self.makedirs(self._executable("."))
+        self.makedirs(TaskPath.executable_path(self._env, "."))
 
-        _, ext = os.path.splitext(program)
+        _, ext = os.path.splitext(program.fullpath)
 
         if ext in COMPILE_RULES:
             COMPILE_RULES[ext](self, program)
         else:
-            raise PipelineItemFailure(f"No rule for compiling {program}.")
-
-        if self.state == State.failed:
-            return None
+            raise PipelineItemFailure(f"No rule for compiling {program:p}.")
 
         self._access_file(program)
         self._access_file(self._load_compiled(self.program))
 
-    def _compile_cpp(self, program: str):
+    def _compile_cpp(self, program: TaskPath):
         cpp_flags = ["-std=c++17", "-O2", "-Wall", "-lm", "-Wshadow", self._c_colors()]
 
         cpp_flags += self._add_stub("cpp")
 
         return self._run_compilation(
-            ["g++", program, "-o", self.target] + cpp_flags, program
+            ["g++", program.fullpath, "-o", self.target.fullpath] + cpp_flags, program
         )
 
-    def _compile_c(self, program: str):
+    def _compile_c(self, program: TaskPath):
         c_flags = ["-std=c17", "-O2", "-Wall", "-lm", "-Wshadow", self._c_colors()]
 
         c_flags += self._add_stub("c")
 
         return self._run_compilation(
-            ["gcc", program, "-o", self.target] + c_flags, program
+            ["gcc", program.fullpath, "-o", self.target.fullpath] + c_flags, program
         )
 
     def _c_colors(self):
@@ -116,18 +116,18 @@ class Compile(ProgramsJob):
         else:
             return "-fdiagnostics-color=never"
 
-    def _compile_pas(self, program: str):
+    def _compile_pas(self, program: TaskPath):
         dir = self._get_build_dir()
-        pas_flags = ["-gl", "-O3", "-Sg", "-o" + self.target, "-FE" + dir]
+        pas_flags = ["-gl", "-O3", "-Sg", "-o" + self.target.fullpath, "-FE" + dir]
 
-        return self._run_compilation(["fpc"] + pas_flags + [program], program)
+        return self._run_compilation(["fpc"] + pas_flags + [program.fullpath], program)
 
-    def _compile_rust(self, program: str):
+    def _compile_rust(self, program: TaskPath):
         return self._run_compilation(
-            ["rustc", "-O", "-o", self.target, program], program
+            ["rustc", "-O", "-o", self.target.fullpath, program.fullpath], program
         )
 
-    def _run_compilation(self, args, program, **kwargs) -> None:
+    def _run_compilation(self, args: list[str], program: TaskPath, **kwargs) -> None:
         self._check_tool(args[0])
 
         comp = subprocess.Popen(args, **kwargs, stderr=subprocess.PIPE)
@@ -139,9 +139,9 @@ class Compile(ProgramsJob):
 
         comp.wait()
         if comp.returncode != 0:
-            raise PipelineItemFailure(f"Compilation of {program} failed.")
+            raise PipelineItemFailure(f"Compilation of {program:p} failed.")
 
-    def _check_tool(self, tool) -> None:
+    def _check_tool(self, tool: str) -> None:
         """Checks that a tool exists."""
         try:
             subprocess.run(
@@ -152,7 +152,7 @@ class Compile(ProgramsJob):
         except FileNotFoundError:
             raise PipelineItemFailure(f"Missing tool: {tool}")
 
-    def _compile_script(self, program: str) -> None:
+    def _compile_script(self, program: TaskPath) -> None:
         if not self.valid_shebang(program):
             raise PipelineItemFailure(
                 f"{program} has invalid shebang. "
@@ -160,18 +160,18 @@ class Compile(ProgramsJob):
                 "Check also that you are using linux eol."
             )
 
-        with open(program, "r", newline="\n") as f:
+        with open(program.fullpath, "r", newline="\n") as f:
             interpreter = f.readline().strip().lstrip("#!")
         self._check_tool(interpreter)
 
-        shutil.copyfile(program, self.target)
+        shutil.copyfile(program.fullpath, self.target.fullpath)
         self._chmod_exec(self.target)
 
     @staticmethod
-    def valid_shebang(filepath: str) -> bool:
+    def valid_shebang(program: TaskPath) -> bool:
         """Check if file has shebang and if the shebang is valid"""
 
-        with open(filepath, "r", newline="\n") as f:
+        with open(program.fullpath, "r", newline="\n") as f:
             first_line = f.readline()
 
         if not first_line.startswith("#!"):
@@ -180,7 +180,7 @@ class Compile(ProgramsJob):
         if first_line.endswith("\r\n"):
             return False
 
-        if os.path.splitext(filepath)[1] == ".py":
+        if os.path.splitext(program.fullpath)[1] == ".py":
             return any(
                 first_line == f"#!/usr/bin/env {interpreter}\n"
                 for interpreter in VALID_PYTHON_INTERPRETERS
@@ -190,9 +190,9 @@ class Compile(ProgramsJob):
             return True
 
     @staticmethod
-    def _chmod_exec(filepath: str) -> None:
-        st = os.stat(filepath)
-        os.chmod(filepath, st.st_mode | 0o111)
+    def _chmod_exec(filepath: TaskPath) -> None:
+        st = os.stat(filepath.fullpath)
+        os.chmod(filepath.fullpath, st.st_mode | 0o111)
 
     def _add_stub(self, extension):
         flags = []

--- a/pisek/jobs/parts/compile.py
+++ b/pisek/jobs/parts/compile.py
@@ -117,8 +117,8 @@ class Compile(ProgramsJob):
             return "-fdiagnostics-color=never"
 
     def _compile_pas(self, program: TaskPath):
-        dir = self._get_build_dir()
-        pas_flags = ["-gl", "-O3", "-Sg", "-o" + self.target.fullpath, "-FE" + dir]
+        build_dir = TaskPath.executable_path(self._env, ".")
+        pas_flags = ["-gl", "-O3", "-Sg", "-o" + self.target.fullpath, "-FE" + build_dir.fullpath]
 
         return self._run_compilation(["fpc"] + pas_flags + [program.fullpath], program)
 

--- a/pisek/jobs/parts/data.py
+++ b/pisek/jobs/parts/data.py
@@ -78,7 +78,7 @@ class DataManager(TaskJobManager):
             if (
                 len(
                     self.filter_by_globs(
-                        [glob], map(lambda p: p.name, self._all_input_files)
+                        [glob], self._all_input_files
                     )
                 )
                 == 0

--- a/pisek/jobs/parts/data.py
+++ b/pisek/jobs/parts/data.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os
+import re
 from typing import Any, Callable
 
 from pisek.jobs.jobs import Job, PipelineItemFailure
@@ -46,7 +46,8 @@ class DataManager(TaskJobManager):
         )
         self._static_outputs = self.globs_to_files(
             map(
-                lambda g: g.replace(".in", ".out"), self._env.config.subtasks.all_globs
+                lambda g: re.sub(r"\.in$", ".out", g),
+                self._env.config.subtasks.all_globs,
             ),
             TaskPath.static_path(self._env, "."),
         )

--- a/pisek/jobs/parts/generator.py
+++ b/pisek/jobs/parts/generator.py
@@ -52,7 +52,7 @@ class GeneratorManager(TaskJobManager):
                 for i, seed in enumerate(seeds):
                     self._inputs.append(
                         input_ := TaskPath.generated_input_file(
-                            self._env, seed, sub_num
+                            self._env, int(sub_num), seed
                         )
                     )
 
@@ -103,7 +103,7 @@ class GeneratorManager(TaskJobManager):
 
 
 class RunOnlineGeneratorMan(TaskJobManager):
-    def __init__(self, subtask: int, seed: int, file: TaskPath):
+    def __init__(self, subtask: int, seed: int, file: str):
         self._subtask = subtask
         self._seed = seed
         self._file = file
@@ -115,7 +115,11 @@ class RunOnlineGeneratorMan(TaskJobManager):
         jobs: list[Job] = [
             compile := Compile(self._env, generator),
             gen := OnlineGeneratorGenerate(
-                self._env, generator, self._file, self._subtask, self._seed
+                self._env,
+                generator,
+                TaskPath.base_path(self._env, self._file),
+                self._subtask,
+                self._seed,
             ),
         ]
         gen.add_prerequisite(compile)

--- a/pisek/jobs/parts/generator.py
+++ b/pisek/jobs/parts/generator.py
@@ -95,7 +95,8 @@ class GeneratorManager(TaskJobManager):
             res["inputs"] = self._inputs
         else:
             res["inputs"] = self.globs_to_files(
-                self._env.config.subtasks.all_globs, TaskPath.generated_path(self._env, ".").fullpath
+                self._env.config.subtasks.all_globs,
+                TaskPath.generated_path(self._env, "."),
             )
 
         return res
@@ -215,7 +216,7 @@ class OnlineGeneratorDeterministic(OnlineGeneratorJob):
         )
 
     def _run(self) -> None:
-        copy_file = TaskPath.base_path(self._env, self.input_.relpath + "2")
+        copy_file = self.input_.replace_suffix(".in2")
         self._gen(copy_file, self.seed, self.subtask)
         if not self._files_equal(self.input_, copy_file):
             raise PipelineItemFailure(
@@ -263,7 +264,8 @@ class OfflineGeneratorGenerate(ProgramsJob):
 
     def _subtask_inputs(self, subtask: str):
         return self.globs_to_files(
-            self._env.config.subtasks[subtask].in_globs, TaskPath.generated_path(self._env, ".").fullpath
+            self._env.config.subtasks[subtask].in_globs,
+            TaskPath.generated_path(self._env, "."),
         )
 
     def _gen(self) -> None:
@@ -276,7 +278,10 @@ class OfflineGeneratorGenerate(ProgramsJob):
         self.makedirs(gen_dir, exist_ok=False)
 
         run_result = self._run_program(
-            ProgramType.in_gen, self.generator, args=[gen_dir.fullpath], print_first_stderr=True
+            ProgramType.in_gen,
+            self.generator,
+            args=[gen_dir.fullpath],
+            print_first_stderr=True,
         )
         self._access_file(gen_dir)
 

--- a/pisek/jobs/parts/generator.py
+++ b/pisek/jobs/parts/generator.py
@@ -38,7 +38,7 @@ class GeneratorManager(TaskJobManager):
         super().__init__("Running generator")
 
     def _get_jobs(self) -> list[Job]:
-        generator = self._resolve_path(self._env.config.generator)
+        generator = TaskPath.base_path(self._env, self._env.config.generator)
 
         jobs: list[Job] = [compile := Compile(self._env, generator)]
 
@@ -51,19 +51,21 @@ class GeneratorManager(TaskJobManager):
                 last_gen: OnlineGeneratorGenerate
                 for i, seed in enumerate(seeds):
                     self._inputs.append(
-                        input_name := util.get_input_name(seed, sub_num)
+                        input_ := TaskPath.generated_input_file(
+                            self._env, seed, sub_num
+                        )
                     )
 
                     jobs.append(
                         gen := OnlineGeneratorGenerate(
-                            self._env, generator, input_name, sub_num, seed
+                            self._env, generator, input_, sub_num, seed
                         )
                     )
                     gen.add_prerequisite(compile)
                     if i == 0:
                         jobs.append(
                             det := OnlineGeneratorDeterministic(
-                                self._env, generator, input_name, sub_num, seed
+                                self._env, generator, input_, sub_num, seed
                             )
                         )
                         det.add_prerequisite(gen)
@@ -74,8 +76,8 @@ class GeneratorManager(TaskJobManager):
                                 sub_num,
                                 last_gen.seed,
                                 gen.seed,
-                                last_gen.input_file,
-                                gen.input_file,
+                                last_gen.input_,
+                                gen.input_,
                             )
                         )
                         rs.add_prerequisite(last_gen)
@@ -93,21 +95,21 @@ class GeneratorManager(TaskJobManager):
             res["inputs"] = self._inputs
         else:
             res["inputs"] = self.globs_to_files(
-                self._env.config.subtasks.all_globs, self._data(GENERATED_SUBDIR)
+                self._env.config.subtasks.all_globs, TaskPath.generated_path(self._env, ".").fullpath
             )
 
         return res
 
 
 class RunOnlineGeneratorMan(TaskJobManager):
-    def __init__(self, subtask: int, seed: int, file: str):
+    def __init__(self, subtask: int, seed: int, file: TaskPath):
         self._subtask = subtask
         self._seed = seed
         self._file = file
         super().__init__("Running generator")
 
     def _get_jobs(self) -> list[Job]:
-        generator = self._resolve_path(self._env.config.generator)
+        generator = TaskPath.base_path(self._env.config.generator)
 
         jobs: list[Job] = [
             compile := Compile(self._env, generator),
@@ -127,8 +129,8 @@ class OnlineGeneratorJob(ProgramsJob):
         self,
         env: Env,
         name: str,
-        generator: str,
-        input_file: str,
+        generator: TaskPath,
+        input_: TaskPath,
         subtask: int,
         seed: int,
         **kwargs,
@@ -137,14 +139,13 @@ class OnlineGeneratorJob(ProgramsJob):
         self.generator = generator
         self.subtask = subtask
         self.seed = seed
-        self.input_name = input_file
-        self.input_file = self._generated_input(input_file)
+        self.input_ = input_
 
-    def _gen(self, input_file: str, seed: int, subtask: int) -> RunResult:
+    def _gen(self, input_file: TaskPath, seed: int, subtask: int) -> RunResult:
         if seed < 0:
             raise PipelineItemFailure(f"Seed {seed} is negative.")
 
-        input_dir = os.path.dirname(input_file)
+        input_dir = os.path.dirname(input_file.fullpath)
 
         difficulty = str(subtask)
         hexa_seed = f"{seed:x}"
@@ -154,7 +155,7 @@ class OnlineGeneratorJob(ProgramsJob):
             self.generator,
             args=[difficulty, hexa_seed],
             stdout=input_file,
-            stderr=self._log_file(os.path.basename(self.input_file), self.generator),
+            stderr=TaskPath.log_file(self._env, self.input_.name, self.generator.name),
             print_first_stderr=True,
         )
         if result.kind != RunResultKind.OK:
@@ -171,24 +172,24 @@ class OnlineGeneratorGenerate(OnlineGeneratorJob):
     def __init__(
         self,
         env: Env,
-        generator: str,
-        input_file: str,
+        generator: TaskPath,
+        input_: TaskPath,
         subtask: int,
         seed: int,
         **kwargs,
     ) -> None:
         super().__init__(
             env=env,
-            name=f"Generate {input_file}",
+            name=f"Generate {input_.name}",
             generator=generator,
-            input_file=input_file,
+            input_=input_,
             subtask=subtask,
             seed=seed,
             **kwargs,
         )
 
     def _run(self) -> RunResult:
-        return self._gen(self.input_file, self.seed, self.subtask)
+        return self._gen(self.input_, self.seed, self.subtask)
 
 
 class OnlineGeneratorDeterministic(OnlineGeneratorJob):
@@ -197,8 +198,8 @@ class OnlineGeneratorDeterministic(OnlineGeneratorJob):
     def __init__(
         self,
         env: Env,
-        generator: str,
-        input_file: str,
+        generator: TaskPath,
+        input_: TaskPath,
         subtask: int,
         seed: int,
         **kwargs,
@@ -207,18 +208,18 @@ class OnlineGeneratorDeterministic(OnlineGeneratorJob):
             env=env,
             name=f"Generator is deterministic (subtask {subtask}, seed {seed:x})",
             generator=generator,
-            input_file=input_file,
+            input_=input_,
             subtask=subtask,
             seed=seed,
             **kwargs,
         )
 
     def _run(self) -> None:
-        copy_file = self._replace_file_suffix(self.input_file, ".in", ".copy")
+        copy_file = TaskPath.base_path(self._env, self.input_.relpath + "2")
         self._gen(copy_file, self.seed, self.subtask)
-        if not self._files_equal(self.input_file, copy_file):
+        if not self._files_equal(self.input_, copy_file):
             raise PipelineItemFailure(
-                f"Generator is not deterministic. Files {self.input_name} and {os.path.basename(copy_file)} differ "
+                f"Generator is not deterministic. Files {self.input_:p} and {copy_file:p} differ "
                 f"(subtask {self.subtask}, seed {self.seed})",
             )
 
@@ -232,19 +233,16 @@ class OnlineGeneratorRespectsSeed(TaskJob):
         subtask: int,
         seed1: int,
         seed2: int,
-        file1: str,
-        file2: str,
+        file1: TaskPath,
+        file2: TaskPath,
         **kwargs,
     ) -> None:
         self.file1, self.file2 = file1, file2
-        self.file1_name, self.file2_name = map(
-            lambda s: str(os.path.basename(s)), (file1, file2)
-        )
         self.subtask = subtask
         self.seed1, self.seed2 = seed1, seed2
         super().__init__(
             env=env,
-            name=f"Generator respects seeds ({self.file1_name} and {self.file2_name} are different)",
+            name=f"Generator respects seeds ({self.file1:n} and {self.file2:n} are different)",
             **kwargs,
         )
 
@@ -252,35 +250,35 @@ class OnlineGeneratorRespectsSeed(TaskJob):
         if self._files_equal(self.file1, self.file2):
             raise PipelineItemFailure(
                 f"Generator doesn't respect seed."
-                f"Files {self.file1_name} (seed {self.seed1:x}) and {self.file2_name} (seed {self.seed2:x}) are same."
+                f"Files {self.file1:n} (seed {self.seed1:x}) and {self.file2:n} (seed {self.seed2:x}) are same."
             )
 
 
 class OfflineGeneratorGenerate(ProgramsJob):
     """Job that generates all inputs using OfflineGenerator."""
 
-    def __init__(self, env: Env, generator: str, **kwargs) -> None:
+    def __init__(self, env: Env, generator: TaskPath, **kwargs) -> None:
         super().__init__(env=env, name="Generate inputs", **kwargs)
         self.generator = generator
 
     def _subtask_inputs(self, subtask: str):
         return self.globs_to_files(
-            self._env.config.subtasks[subtask].in_globs, self._generated_input(".")
+            self._env.config.subtasks[subtask].in_globs, TaskPath.generated_path(self._env, ".").fullpath
         )
 
     def _gen(self) -> None:
         """Generates all inputs."""
+        gen_dir = TaskPath.generated_path(self._env, ".")
         try:
-            shutil.rmtree(self._generated_input("."))
+            shutil.rmtree(gen_dir.fullpath)
         except FileNotFoundError:
             pass
-        self.makedirs(self._generated_input("."), exist_ok=False)
+        self.makedirs(gen_dir, exist_ok=False)
 
-        gen_dir = self._generated_input(".")
         run_result = self._run_program(
-            ProgramType.in_gen, self.generator, args=[gen_dir], print_first_stderr=True
+            ProgramType.in_gen, self.generator, args=[gen_dir.fullpath], print_first_stderr=True
         )
-        self._access_file(self._generated_input("."))
+        self._access_file(gen_dir)
 
         if run_result.kind != RunResultKind.OK:
             raise self._create_program_failure(f"Generator failed:", run_result)

--- a/pisek/jobs/parts/generator.py
+++ b/pisek/jobs/parts/generator.py
@@ -22,9 +22,10 @@ from typing import Any
 
 import pisek.util as util
 from pisek.env import Env
+from pisek.paths import TaskPath, GENERATED_SUBDIR
 from pisek.task_config import ProgramType
 from pisek.jobs.jobs import Job, PipelineItemFailure
-from pisek.jobs.parts.task_job import TaskJob, TaskJobManager, GENERATED_SUBDIR
+from pisek.jobs.parts.task_job import TaskJob, TaskJobManager
 from pisek.jobs.parts.program import RunResult, RunResultKind, ProgramsJob
 from pisek.jobs.parts.compile import Compile
 

--- a/pisek/jobs/parts/judge.py
+++ b/pisek/jobs/parts/judge.py
@@ -39,14 +39,15 @@ DIFF_NAME = "diff.sh"
 class JudgeManager(TaskJobManager):
     """Manager that prepares and test judge."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("Preparing judge")
 
     def _get_jobs(self) -> list[Job]:
         jobs: list[Job] = []
+        judge = TaskPath.base_path(self._env, self._env.config.judge)
         if self._env.config.judge_type != "diff":
             jobs.append(
-                comp := Compile(self._env, TaskPath.base_path(self._env, self._env.config.judge))
+                comp := Compile(self._env, judge)
             )
 
         samples = self._get_samples()
@@ -55,8 +56,8 @@ class JudgeManager(TaskJobManager):
 
         for inp, out in samples:
             jobs.append(
-                judge := judge_job(
-                    self._env.config.judge,
+                judge_j := judge_job(
+                    judge,
                     inp,
                     out,
                     out,
@@ -67,7 +68,7 @@ class JudgeManager(TaskJobManager):
                 )
             )
             if self._env.config.judge_type != "diff":
-                judge.add_prerequisite(comp)
+                judge_j.add_prerequisite(comp)
 
             JOBS = [(Incomplete, 10), (ChaosMonkey, 50)]
 
@@ -78,13 +79,11 @@ class JudgeManager(TaskJobManager):
             for job, times in JOBS:
                 for i in range(times):
                     seed = seeds.pop()
-                    inv_out = self._replace_file_suffix(
-                        out, ".out", f".{seed:x}.invalid"
-                    )
+                    inv_out = TaskPath.invalid_file(self._env, out.name, seed)
                     jobs += [
                         invalidate := job(self._env, out, inv_out, seed),
                         run_judge := judge_job(
-                            self._env.config.judge,
+                            judge,
                             inp,
                             inv_out,
                             out,
@@ -102,8 +101,8 @@ class JudgeManager(TaskJobManager):
 
 class RunKasiopeaJudgeMan(TaskJobManager):
     def __init__(
-        self, subtask: int, seed: int, input_: str, output: str, correct_output: str
-    ):
+        self, subtask: int, seed: int, input_: TaskPath, output: TaskPath, correct_output: TaskPath 
+    ) -> None:
         self._subtask = subtask
         self._seed = seed
         self._input_file = input_
@@ -112,8 +111,8 @@ class RunKasiopeaJudgeMan(TaskJobManager):
         super().__init__("Running judge")
 
     def _get_jobs(self) -> list[Job]:
-        judge_program = self._resolve_path(self._env.config.judge)
-        clean_output = self._output_file + ".clean"
+        judge_program = TaskPath.base_path(self._env, self._env.config.judge)
+        clean_output = TaskPath.sanitized_file(self._env, self._output_file.name)
 
         jobs: list[Job] = [
             sanitize := Sanitize(self._env, self._output_file, clean_output),
@@ -155,17 +154,16 @@ class RunJudge(ProgramsJob):
         self,
         env: Env,
         name: str,
-        judge: str,
-        input_name: str,
-        judge_log_file_name: str,
+        judge: TaskPath,
+        input_: TaskPath,
+        judge_log_file: TaskPath,
         expected_points: Optional[float],
         **kwargs,
     ) -> None:
         super().__init__(env=env, name=name, **kwargs)
         self.judge = judge
-        self.input_name = input_name
-        self.input = self._input(input_name)
-        self.judge_log_file = self._log_file(judge_log_file_name, judge)
+        self.input = input_
+        self.judge_log_file = judge_log_file
         self.expected_points = expected_points
 
     @cache
@@ -236,18 +234,17 @@ class RunJudge(ProgramsJob):
         if self.result is None:
             raise RuntimeError(f"Job {self.name} has not finished yet.")
 
-        judge = os.path.basename(self.judge)
         judging = self._judging_message()
         if self.result.verdict == Verdict.ok:
-            head = f"{judge} accepted {judging}"
+            head = f"{self.judge:n} accepted {judging}"
         elif self.result.verdict == Verdict.wrong_answer:
-            head = f"{judge} rejected {judging}"
+            head = f"{self.judge:n} rejected {judging}"
         elif self.result.verdict == Verdict.partial:
-            head = f"{judge} partially accepted {judging}"
+            head = f"{self.judge:n} partially accepted {judging}"
         elif self.result.verdict == Verdict.error:
-            head = f"Solution failed on input {self.input_name}"
+            head = f"Solution failed on input {self.input}"
         elif self.result.verdict == Verdict.timeout:
-            head = f"Solution did timeout on input {self.input_name}"
+            head = f"Solution did timeout on input {self.input}"
 
         text = f"{head}:\n{tab(self.result.output)}"
         if self.result.diff != "":
@@ -262,14 +259,14 @@ class RunCMSJudge(RunJudge):
     def __init__(
         self,
         env: Env,
-        judge_log_file_name: str,
+        judge_log_file: TaskPath,
         **kwargs,
     ) -> None:
-        super().__init__(env=env, judge_log_file_name=judge_log_file_name, **kwargs)
-        self.points_file = self._points_file(judge_log_file_name)
+        super().__init__(env=env, judge_log_file=judge_log_file, **kwargs)
+        self.points_file = TaskPath.points_file(self._env, judge_log_file.name)
 
     def _load_points(self, result: RunResult) -> float:
-        points_str = result.raw_stdout().split("\n")[0]
+        points_str = result.raw_stdout(self._access_file).split("\n")[0]
         try:
             points = float(points_str)
         except ValueError:
@@ -299,7 +296,7 @@ class RunCMSJudge(RunJudge):
                 points,
                 self._solution_run_res.time,
                 self._solution_run_res.wall_time,
-                judge_run_result.raw_stderr(),
+                judge_run_result.raw_stderr(self._access_file),
                 self._quote_program(judge_run_result),
             )
         else:
@@ -315,27 +312,24 @@ class RunBatchJudge(RunJudge):
         self,
         env: Env,
         judge: TaskPath,
-        input_name: TaskPath,
-        output_name: TaskPath,
+        input_: TaskPath,
+        output: TaskPath,
         correct_output: TaskPath,
         expected_points: Optional[float],
         **kwargs,
     ) -> None:
         super().__init__(
             env=env,
-            name=JUDGE_JOB_NAME.replace(r"(\w+)", os.path.basename(output_name), 1),
+            name=JUDGE_JOB_NAME.replace(r"(\w+)", output.name, 1),
             judge=judge,
-            input_name=input_name,
-            judge_log_file_name=output_name,
+            input_=input_,
+            judge_log_file=TaskPath.log_file(self._env, output.name, judge.name),
             expected_points=expected_points,
             **kwargs,
         )
-        self.output_name = output_name
-        self.output = (
-            self._invalid_output if output_name.endswith(".invalid") else self._output
-        )(output_name)
+        self.output = output
         self.correct_output_name = correct_output
-        self.correct_output = self._output(correct_output)
+        self.correct_output = correct_output
 
     def _get_solution_run_res(self) -> RunResult:
         if "run_solution" in self.prerequisites_results:
@@ -346,7 +340,7 @@ class RunBatchJudge(RunJudge):
             return RunResult(RunResultKind.OK, 0, 0.0, 0.0)
 
     def _judging_message(self) -> str:
-        return f"output {self.output_name} for input {self.input_name}"
+        return f"output {self.output:n} for input {self.input}"
 
     def _nice_diff(self) -> str:
         """Create a nice diff between output and correct output."""
@@ -360,17 +354,17 @@ class RunDiffJudge(RunBatchJudge):
     def __init__(
         self,
         env: Env,
-        judge: str,
-        input_name: str,
-        output_name: str,
-        correct_output: str,
+        judge: TaskPath,
+        input_: TaskPath,
+        output: TaskPath,
+        correct_output: TaskPath,
         expected_points: Optional[float],
     ) -> None:
         super().__init__(
             env=env,
             judge=judge,
-            input_name=input_name,
-            output_name=output_name,
+            input_=input_,
+            output=output,
             correct_output=correct_output,
             expected_points=expected_points,
         )
@@ -379,7 +373,7 @@ class RunDiffJudge(RunBatchJudge):
         self._access_file(self.output)
         self._access_file(self.correct_output)
         diff = subprocess.run(
-            ["diff", "-Bbq", self.output, self.correct_output],
+            ["diff", "-Bbq", self.output.fullpath, self.correct_output.fullpath],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -424,8 +418,8 @@ class RunKasiopeaJudge(RunBatchJudge):
         self,
         env: Env,
         judge: TaskPath,
-        input_name: TaskPath,
-        output_name: TaskPath,
+        input_: TaskPath,
+        output: TaskPath,
         correct_output: TaskPath,
         subtask: int,
         seed: str,
@@ -435,8 +429,8 @@ class RunKasiopeaJudge(RunBatchJudge):
         super().__init__(
             env=env,
             judge=judge,
-            input_name=input_name,
-            output_name=output_name,
+            input_=input_,
+            output=output,
             correct_output=correct_output,
             expected_points=expected_points,
             **kwargs,
@@ -447,10 +441,10 @@ class RunKasiopeaJudge(RunBatchJudge):
     def _judge(self) -> SolutionResult:
         envs = {}
         if self._env.config.judge_needs_in:
-            envs["TEST_INPUT"] = self.input
+            envs["TEST_INPUT"] = self.input.fullpath
             self._access_file(self.input)
         if self._env.config.judge_needs_out:
-            envs["TEST_OUTPUT"] = self.correct_output
+            envs["TEST_OUTPUT"] = self.correct_output.fullpath
             self._access_file(self.correct_output)
 
         result = self._run_program(
@@ -467,7 +461,7 @@ class RunKasiopeaJudge(RunBatchJudge):
                 1.0,
                 self._solution_run_res.time,
                 self._solution_run_res.wall_time,
-                result.raw_stderr(),
+                result.raw_stderr(self._access_file),
                 self._quote_program(result),
             )
         elif result.returncode == 1:
@@ -476,13 +470,13 @@ class RunKasiopeaJudge(RunBatchJudge):
                 0.0,
                 self._solution_run_res.time,
                 self._solution_run_res.wall_time,
-                result.raw_stderr(),
+                result.raw_stderr(self._access_file),
                 self._quote_program(result),
                 self._nice_diff(),
             )
         else:
             raise self._create_program_failure(
-                f"Judge failed on output {self.output_name}:", result
+                f"Judge failed on output {self.output:n}:", result
             )
 
 
@@ -493,8 +487,8 @@ class RunCMSBatchJudge(RunBatchJudge, RunCMSJudge):
         self,
         env: Env,
         judge: TaskPath,
-        input_name: TaskPath,
-        output_name: TaskPath,
+        input_: TaskPath,
+        output: TaskPath,
         correct_output: TaskPath,
         expected_points: Optional[float],
         **kwargs,
@@ -502,8 +496,8 @@ class RunCMSBatchJudge(RunBatchJudge, RunCMSJudge):
         super().__init__(
             env=env,
             judge=judge,
-            input_name=input_name,
-            output_name=output_name,
+            input_=input_,
+            output=output,
             correct_output=correct_output,
             expected_points=expected_points,
             **kwargs,
@@ -516,7 +510,7 @@ class RunCMSBatchJudge(RunBatchJudge, RunCMSJudge):
         result = self._run_program(
             ProgramType.judge,
             self.judge,
-            args=[self.input, self.correct_output, self.output],
+            args=[self.input.fullpath, self.correct_output.fullpath, self.output.fullpath],
             stdout=self.points_file,
             stderr=self.judge_log_file,
         )
@@ -528,9 +522,9 @@ class RunCMSBatchJudge(RunBatchJudge, RunCMSJudge):
 
 
 def judge_job(
-    judge: str,
-    input_name: TaskPath,
-    output_name: TaskPath,
+    judge: TaskPath,
+    input_: TaskPath,
+    output: TaskPath,
     correct_output: TaskPath,
     subtask: int,
     get_seed: Callable[[], str],
@@ -540,18 +534,18 @@ def judge_job(
     """Returns JudgeJob according to contest type."""
     if env.config.judge_type == "diff":
         return RunDiffJudge(
-            env, judge, input_name, output_name, correct_output, expected_points
+            env, judge, input_, output, correct_output, expected_points
         )
     elif env.config.contest_type == "cms":
         return RunCMSBatchJudge(
-            env, judge, input_name, output_name, correct_output, expected_points
+            env, judge, input_, output, correct_output, expected_points
         )
     else:
         return RunKasiopeaJudge(
             env,
             judge,
-            input_name,
-            output_name,
+            input_,
+            output,
             correct_output,
             subtask,
             get_seed(),

--- a/pisek/jobs/parts/judge.py
+++ b/pisek/jobs/parts/judge.py
@@ -22,6 +22,7 @@ from typing import Optional, Union, Callable
 import subprocess
 
 from pisek.env import Env
+from pisek.paths import TaskPath
 from pisek.task_config import ProgramType
 from pisek.jobs.jobs import State, Job, PipelineItemFailure
 from pisek.terminal import tab, colored
@@ -45,7 +46,7 @@ class JudgeManager(TaskJobManager):
         jobs: list[Job] = []
         if self._env.config.judge_type != "diff":
             jobs.append(
-                comp := Compile(self._env, self._resolve_path(self._env.config.judge))
+                comp := Compile(self._env, TaskPath.base_path(self._env, self._env.config.judge))
             )
 
         samples = self._get_samples()
@@ -313,10 +314,10 @@ class RunBatchJudge(RunJudge):
     def __init__(
         self,
         env: Env,
-        judge: str,
-        input_name: str,
-        output_name: str,
-        correct_output: str,
+        judge: TaskPath,
+        input_name: TaskPath,
+        output_name: TaskPath,
+        correct_output: TaskPath,
         expected_points: Optional[float],
         **kwargs,
     ) -> None:
@@ -422,10 +423,10 @@ class RunKasiopeaJudge(RunBatchJudge):
     def __init__(
         self,
         env: Env,
-        judge: str,
-        input_name: str,
-        output_name: str,
-        correct_output: str,
+        judge: TaskPath,
+        input_name: TaskPath,
+        output_name: TaskPath,
+        correct_output: TaskPath,
         subtask: int,
         seed: str,
         expected_points: Optional[float],
@@ -491,10 +492,10 @@ class RunCMSBatchJudge(RunBatchJudge, RunCMSJudge):
     def __init__(
         self,
         env: Env,
-        judge: str,
-        input_name: str,
-        output_name: str,
-        correct_output: str,
+        judge: TaskPath,
+        input_name: TaskPath,
+        output_name: TaskPath,
+        correct_output: TaskPath,
         expected_points: Optional[float],
         **kwargs,
     ) -> None:
@@ -528,9 +529,9 @@ class RunCMSBatchJudge(RunBatchJudge, RunCMSJudge):
 
 def judge_job(
     judge: str,
-    input_name: str,
-    output_name: str,
-    correct_output: str,
+    input_name: TaskPath,
+    output_name: TaskPath,
+    correct_output: TaskPath,
     subtask: int,
     get_seed: Callable[[], str],
     expected_points: Optional[float],

--- a/pisek/jobs/parts/program.py
+++ b/pisek/jobs/parts/program.py
@@ -204,7 +204,7 @@ class ProgramsJob(TaskJob):
         executable = TaskPath.executable_file(self._env, program.relpath)
         if not self._file_exists(executable):
             raise PipelineItemFailure(
-                f"Program {executable.relpath} does not exist, "
+                f"Program {executable:p} does not exist, "
                 f"although it should have been compiled already."
             )
         return executable

--- a/pisek/jobs/parts/program.py
+++ b/pisek/jobs/parts/program.py
@@ -181,7 +181,10 @@ class ProgramPoolItem:
         minibox_args.append(f"--meta={meta_file}")
 
         result["args"] = (
-            [minibox] + minibox_args + ["--run", "--", self.executable.fullpath] + self.args
+            [minibox]
+            + minibox_args
+            + ["--run", "--", self.executable.fullpath]
+            + self.args
         )
         return result
 
@@ -221,10 +224,10 @@ class ProgramsJob(TaskJob):
         if isinstance(stdin, TaskPath):
             self._access_file(stdin)
         if isinstance(stdout, TaskPath):
-            self.makedirs(stdout)
+            self.make_filedirs(stdout)
             self._access_file(stdout)
         if isinstance(stderr, TaskPath):
-            self.makedirs(stderr)
+            self.make_filedirs(stderr)
             self._access_file(stderr)
 
         self._program_pool.append(

--- a/pisek/jobs/parts/solution.py
+++ b/pisek/jobs/parts/solution.py
@@ -422,7 +422,7 @@ class RunCommunication(RunCMSJudge, RunSolution):
             judge=judge,
             input_name=input_name,
             expected_points=expected_points,
-            judge_log_file_name=os.path.basename(
+            judge_log_file=os.path.basename(
                 self._output_from_input(input_name, solution)
             ),
             solution=solution,
@@ -481,4 +481,4 @@ class RunCommunication(RunCMSJudge, RunSolution):
         return self._load_solution_result(self._judge_run_result)
 
     def _judging_message(self) -> str:
-        return f"solution {os.path.basename(self.solution)} on input {self.input_name}"
+        return f"solution {os.path.basename(self.solution)} on input {self.input}"

--- a/pisek/jobs/parts/task_job.py
+++ b/pisek/jobs/parts/task_job.py
@@ -67,16 +67,29 @@ class TaskHelper:
         }
 
     @staticmethod
-    def filter_by_globs(globs: Iterable[str], files: Iterable[TaskPath]) -> list[TaskPath]:
-        return [file for file in files if any(fnmatch.fnmatch(file.name, g) for g in globs)]
+    def filter_by_globs(
+        globs: Iterable[str], files: Iterable[TaskPath]
+    ) -> list[TaskPath]:
+        return [
+            file for file in files if any(fnmatch.fnmatch(file.name, g) for g in globs)
+        ]
 
     def globs_to_files(
-        self, globs: list[str], directory: TaskPath
+        self, globs: Iterable[str], directory: TaskPath
     ) -> list[TaskPath]:
         files: list[str] = list(
-            sorted(set(sum((glob.glob(g, root_dir=directory.fullpath) for g in globs), start=[])))
+            sorted(
+                set(
+                    sum(
+                        (glob.glob(g, root_dir=directory.fullpath) for g in globs),
+                        start=[],
+                    )
+                )
+            )
         )
-        return [TaskPath.from_abspath(self._env, directory.fullpath, file) for file in files]
+        return [
+            TaskPath.from_abspath(self._env, directory.fullpath, file) for file in files
+        ]
 
     @staticmethod
     def _short_text(text: str, max_lines: int = 15, max_chars: int = 100) -> str:
@@ -107,7 +120,7 @@ class TaskJobManager(StatusJobManager, TaskHelper):
     def _get_samples(self) -> list[tuple[TaskPath, TaskPath]]:
         """Returns the list [(sample1.in, sample1.out), …]."""
         ins = self._subtask_inputs(self._env.config.subtasks["0"])
-        outs = (inp.replace_suffix(".out") for inp in ins)
+        outs = (TaskPath.output_static_file(self._env, inp.name) for inp in ins)
         return list(zip(ins, outs))
 
     def _all_inputs(self) -> list[TaskPath]:

--- a/pisek/jobs/parts/task_job.py
+++ b/pisek/jobs/parts/task_job.py
@@ -70,12 +70,14 @@ class TaskHelper:
     def filter_by_globs(globs: Iterable[str], files: Iterable[str]):
         return [file for file in files if any(fnmatch.fnmatch(file, g) for g in globs)]
 
-    @staticmethod
-    def globs_to_files(globs: list[str], directory: Optional[str] = None) -> list[str]:
-        files: list[str] = sum(
-            (glob.glob(g, root_dir=directory) for g in globs), start=[]
+    def globs_to_files(
+        self, globs: list[str], directory: Optional[TaskPath] = None
+    ) -> list[TaskPath]:
+        dir_path = directory.fullpath if directory else None
+        files: list[str] = list(
+            sorted(set(sum((glob.glob(g, root_dir=dir_path) for g in globs), start=[])))
         )
-        return list(sorted(set(files)))
+        return [TaskPath.from_abspath(self._env, dir_path, file) for file in files]
 
     @staticmethod
     def _short_text(text: str, max_lines: int = 15, max_chars: int = 100) -> str:
@@ -93,10 +95,11 @@ class TaskHelper:
 
     @staticmethod
     def makedirs(path: TaskPath, exist_ok: bool = True):
-        dirs = path.fullpath
-        if os.path.isfile(dirs):
-            dirs = os.path.dirname(dirs)
-        os.makedirs(dirs, exist_ok=exist_ok)
+        os.makedirs(path.fullpath, exist_ok=exist_ok)
+
+    @staticmethod
+    def make_filedirs(path: TaskPath, exist_ok: bool = True):
+        os.makedirs(os.path.dirname(path.fullpath), exist_ok=exist_ok)
 
 
 class TaskJobManager(StatusJobManager, TaskHelper):

--- a/pisek/jobs/parts/task_job.py
+++ b/pisek/jobs/parts/task_job.py
@@ -77,16 +77,11 @@ class TaskHelper:
     def globs_to_files(
         self, globs: Iterable[str], directory: TaskPath
     ) -> list[TaskPath]:
-        files: list[str] = list(
-            sorted(
-                set(
-                    sum(
-                        (glob.glob(g, root_dir=directory.fullpath) for g in globs),
-                        start=[],
-                    )
-                )
-            )
+        files: list[str] = sum(
+            (glob.glob(g, root_dir=directory.fullpath) for g in globs),
+            start=[],
         )
+        files = list(sorted(set(files)))
         return [
             TaskPath.from_abspath(self._env, directory.fullpath, file) for file in files
         ]

--- a/pisek/jobs/parts/testing_log.py
+++ b/pisek/jobs/parts/testing_log.py
@@ -16,6 +16,7 @@
 import json
 from typing import Any
 
+from pisek.paths import TaskPath
 from pisek.jobs.jobs import Job, PipelineItemFailure
 from pisek.terminal import colored
 from pisek.jobs.parts.task_job import (
@@ -67,5 +68,5 @@ class CreateTestingLog(TaskJobManager):
             else:
                 self._print(colored(MSG, self._env, "yellow"))
 
-        with open(self._resolve_path(TESTING_LOG), "w") as f:
+        with open(TaskPath.base_path(self._env, TESTING_LOG).fullpath, "w") as f:
             json.dump(log, f, indent=4)

--- a/pisek/jobs/parts/tools.py
+++ b/pisek/jobs/parts/tools.py
@@ -34,7 +34,7 @@ class ToolsManager(TaskJobManager):
         super().__init__("Preparing tools")
 
     def _get_jobs(self) -> list[Job]:
-        self.makedirs(TaskPath.executable_path(self._env, ".").relpath)
+        self.makedirs(TaskPath.executable_path(self._env, "."))
         jobs: list[Job] = [
             PrepareMinibox(self._env),
             PrepareTextPreprocessor(self._env),
@@ -57,7 +57,7 @@ class PrepareMinibox(TaskJob):
                 "gcc",
                 source,
                 "-o",
-                executable.relpath,
+                executable.fullpath,
                 "-std=gnu11",
                 "-D_GNU_SOURCE",
                 "-O2",
@@ -87,7 +87,7 @@ class PrepareTextPreprocessor(TaskJob):
                 "gcc",
                 source,
                 "-o",
-                executable.relpath,
+                executable.fullpath,
                 "-std=gnu11",
                 "-O2",
                 "-Wall",
@@ -109,7 +109,7 @@ class SanitizeAbstract(ProgramsJob):
         )
         if result.returncode == 43:
             raise self._create_program_failure(
-                f"Text preprocessor failed on file: {input_.relpath}", result
+                f"Text preprocessor failed on file: {input_:p}", result
             )
 
 
@@ -122,7 +122,7 @@ class Sanitize(SanitizeAbstract):
         self.input = input_
         self.output = output if output else TaskPath.sanitized_file(input_)
         super().__init__(
-            env=env, name=f"Sanitize {self.input_.name} -> {self.output.name}", **kwargs
+            env=env, name=f"Sanitize {self.input_:n} -> {self.output:n}", **kwargs
         )
 
     def _run(self):
@@ -137,11 +137,11 @@ class IsClean(SanitizeAbstract):
     ) -> None:
         self.input = input_
         self.output = output if output else TaskPath.sanitized_file(input_)
-        super().__init__(env=env, name=f"{input_.name} is clean", **kwargs)
+        super().__init__(env=env, name=f"{input_:n} is clean", **kwargs)
 
     def _run(self):
         self._sanitize(self.input, self.output)
         if not self._files_equal(self.input, self.output):
             raise PipelineItemFailure(
-                f"File {self.input.name} is not clean. Check encoding, missing newline at the end or \\r."
+                f"File {self.input:n} is not clean. Check encoding, missing newline at the end or \\r."
             )

--- a/pisek/jobs/parts/tools.py
+++ b/pisek/jobs/parts/tools.py
@@ -105,7 +105,10 @@ class SanitizeAbstract(ProgramsJob):
 
     def _sanitize(self, input_: TaskPath, output: TaskPath) -> None:
         result = self._run_program(
-            ProgramType.tool, "text-preproc", stdin=input_, stdout=output
+            ProgramType.tool,
+            TaskPath.executable_path(self._env, "text-preproc"),
+            stdin=input_,
+            stdout=output,
         )
         if result.returncode == 43:
             raise self._create_program_failure(
@@ -120,9 +123,11 @@ class Sanitize(SanitizeAbstract):
         self, env: Env, input_: TaskPath, output: Optional[TaskPath] = None, **kwargs
     ) -> None:
         self.input = input_
-        self.output = output if output else TaskPath.sanitized_file(input_)
+        self.output = (
+            output if output else TaskPath.sanitized_file(self._env, input_.relpath)
+        )
         super().__init__(
-            env=env, name=f"Sanitize {self.input_:n} -> {self.output:n}", **kwargs
+            env=env, name=f"Sanitize {self.input:n} -> {self.output:n}", **kwargs
         )
 
     def _run(self):
@@ -136,8 +141,10 @@ class IsClean(SanitizeAbstract):
         self, env: Env, input_: TaskPath, output: Optional[TaskPath] = None, **kwargs
     ) -> None:
         self.input = input_
-        self.output = output if output else TaskPath.sanitized_file(input_)
-        super().__init__(env=env, name=f"{input_:n} is clean", **kwargs)
+        self.output = (
+            output if output else TaskPath.sanitized_file(self._env, input_.relpath)
+        )
+        super().__init__(env=env, name=f"{self.input:n} is clean", **kwargs)
 
     def _run(self):
         self._sanitize(self.input, self.output)

--- a/pisek/jobs/parts/tools.py
+++ b/pisek/jobs/parts/tools.py
@@ -21,6 +21,7 @@ from typing import Optional
 import subprocess
 from pisek.jobs.jobs import State, Job, PipelineItemFailure
 from pisek.env import Env
+from pisek.paths import TaskPath
 from pisek.task_config import ProgramType
 from pisek.jobs.parts.task_job import TaskJob, TaskJobManager
 from pisek.jobs.parts.program import ProgramsJob
@@ -33,7 +34,7 @@ class ToolsManager(TaskJobManager):
         super().__init__("Preparing tools")
 
     def _get_jobs(self) -> list[Job]:
-        self.makedirs(self._executable("."))
+        self.makedirs(TaskPath.executable_path(self._env, ".").relpath)
         jobs: list[Job] = [
             PrepareMinibox(self._env),
             PrepareTextPreprocessor(self._env),
@@ -49,14 +50,14 @@ class PrepareMinibox(TaskJob):
 
     def _run(self):
         source = files("pisek").joinpath("tools/minibox.c")
-        executable = self._executable("minibox")
+        executable = TaskPath.executable_path(self._env, "minibox")
         self._access_file(executable)
         gcc = subprocess.run(
             [
                 "gcc",
                 source,
                 "-o",
-                executable,
+                executable.relpath,
                 "-std=gnu11",
                 "-D_GNU_SOURCE",
                 "-O2",
@@ -79,14 +80,14 @@ class PrepareTextPreprocessor(TaskJob):
 
     def _run(self):
         source = files("pisek").joinpath("tools/text-preproc.c")
-        executable = self._executable("text-preproc")
+        executable = TaskPath.executable_path(self._env, "text-preproc")
         self._access_file(executable)
         gcc = subprocess.run(
             [
                 "gcc",
                 source,
                 "-o",
-                executable,
+                executable.relpath,
                 "-std=gnu11",
                 "-O2",
                 "-Wall",
@@ -102,13 +103,13 @@ class PrepareTextPreprocessor(TaskJob):
 class SanitizeAbstract(ProgramsJob):
     """Abstract job that has method for file sanitization."""
 
-    def _sanitize(self, input_: str, output: str) -> None:
+    def _sanitize(self, input_: TaskPath, output: TaskPath) -> None:
         result = self._run_program(
             ProgramType.tool, "text-preproc", stdin=input_, stdout=output
         )
         if result.returncode == 43:
             raise self._create_program_failure(
-                f"Text preprocessor failed on file: {input_}", result
+                f"Text preprocessor failed on file: {input_.relpath}", result
             )
 
 
@@ -116,11 +117,13 @@ class Sanitize(SanitizeAbstract):
     """Sanitize text file using Text Preprocessor."""
 
     def __init__(
-        self, env: Env, input_: str, output: Optional[str] = None, **kwargs
+        self, env: Env, input_: TaskPath, output: Optional[TaskPath] = None, **kwargs
     ) -> None:
-        super().__init__(env=env, name=f"Sanitize {input_} -> {output}", **kwargs)
-        self.input = self._data(input_)
-        self.output = self._data(output if output is not None else input_ + ".clean")
+        self.input = input_
+        self.output = output if output else TaskPath.sanitized_file(input_)
+        super().__init__(
+            env=env, name=f"Sanitize {self.input_.name} -> {self.output.name}", **kwargs
+        )
 
     def _run(self):
         return self._sanitize(self.input, self.output)
@@ -130,20 +133,15 @@ class IsClean(SanitizeAbstract):
     """Check that file is same after sanitizing with Text Preprocessor."""
 
     def __init__(
-        self, env: Env, input_: str, output: Optional[str] = None, **kwargs
+        self, env: Env, input_: TaskPath, output: Optional[TaskPath] = None, **kwargs
     ) -> None:
-        super().__init__(env=env, name=f"{os.path.basename(input_)} is clean", **kwargs)
         self.input = input_
-        self.output = self._sanitized(
-            output if output is not None else os.path.basename(input_) + ".clean"
-        )
+        self.output = output if output else TaskPath.sanitized_file(input_)
+        super().__init__(env=env, name=f"{input_.name} is clean", **kwargs)
 
     def _run(self):
         self._sanitize(self.input, self.output)
-        if self.state == State.failed:
-            return None
-
         if not self._files_equal(self.input, self.output):
             raise PipelineItemFailure(
-                f"File {self.input} is not clean. Check encoding, missing newline at the end or \\r."
+                f"File {self.input.name} is not clean. Check encoding, missing newline at the end or \\r."
             )

--- a/pisek/paths.py
+++ b/pisek/paths.py
@@ -70,7 +70,9 @@ class TaskPath:
 
     @staticmethod
     def from_abspath(env: Env, *path: str) -> "TaskPath":
-        return TaskPath.base_path(env, os.path.relpath(os.path.join(*path), env.task_dir))
+        return TaskPath.base_path(
+            env, os.path.relpath(os.path.join(*path), env.task_dir)
+        )
 
     @staticmethod
     def static_path(env: Env, *path: str) -> "TaskPath":
@@ -98,8 +100,8 @@ class TaskPath:
         return TaskPath.data_path(env, GENERATED_SUBDIR, *path)
 
     @staticmethod
-    def generated_input_file(env: Env, subtask: int, seed: str) -> "TaskPath":
-        return TaskPath(env, f"{subtask:02}_{seed:x}.in")
+    def generated_input_file(env: Env, subtask: int, seed: int) -> "TaskPath":
+        return TaskPath.generated_path(env, f"{subtask:02}_{seed:x}.in")
 
     @staticmethod
     def input_path(env: Env, *path: str) -> "TaskPath":
@@ -123,6 +125,11 @@ class TaskPath:
         input_name = os.path.splitext(os.path.basename(input_name))[0]
         solution = os.path.basename(solution)
         return TaskPath.output_path(env, f"{input_name}.{solution}.out")
+
+    @staticmethod
+    def output_static_file(env: Env, name: str) -> "TaskPath":
+        name = os.path.splitext(name)[0]
+        return TaskPath.output_path(env, f"{name}.out")
 
     @staticmethod
     def sanitized_path(env: Env, *path: str) -> "TaskPath":
@@ -150,7 +157,9 @@ class TaskPath:
 
 
 def task_path_representer(dumper, task_path: TaskPath):
-    return dumper.represent_sequence("!TaskPath", [task_path._task_path, task_path.relpath])
+    return dumper.represent_sequence(
+        "!TaskPath", [task_path._task_path, task_path.relpath]
+    )
 
 
 def task_path_constructor(loader, value):

--- a/pisek/paths.py
+++ b/pisek/paths.py
@@ -53,8 +53,11 @@ class TaskPath:
                     f"Invalid format specifier '{__format_spec}' for object of type '{self.__class__.__name__}'"
                 )
 
-    def __eq__(self, other_path: "TaskPath") -> bool:
-        return self.relpath == other_path.relpath
+    def __eq__(self, other_path) -> bool:
+        if isinstance(other_path, TaskPath):
+            return self.relpath == other_path.relpath
+        else:
+            return False
 
     def replace_suffix(self, new_suffix: str) -> "TaskPath":
         path = os.path.splitext(self.relpath)[0] + new_suffix

--- a/pisek/paths.py
+++ b/pisek/paths.py
@@ -1,0 +1,96 @@
+# pisek  - Tool for developing tasks for programming competitions.
+#
+# Copyright (c)   2019 - 2022 Václav Volhejn <vaclav.volhejn@gmail.com>
+# Copyright (c)   2019 - 2022 Jiří Beneš <mail@jiribenes.com>
+# Copyright (c)   2020 - 2022 Michal Töpfer <michal.topfer@gmail.com>
+# Copyright (c)   2022        Jiri Kalvoda <jirikalvoda@kam.mff.cuni.cz>
+# Copyright (c)   2023        Daniel Skýpala <daniel@honza.info>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+
+from pisek.env import Env
+
+BUILD_DIR = "build/"
+
+GENERATED_SUBDIR = "generated/"
+INPUTS_SUBDIR = "inputs/"
+INVALID_OUTPUTS_SUBDIR = "invalid/"
+OUTPUTS_SUBDIR = "outputs/"
+SANITIZED_SUBDIR = "sanitized/"
+LOG_SUBDIR = "log/"
+
+
+class TaskPath:
+    """Class representing a path to task file."""
+
+    def __init__(self, task_path, *path: str):
+        path = os.path.normpath(os.path.join(*path))
+        self.fullpath = os.path.join(task_path, path)
+        self.relpath = path
+        self.name = os.path.basename(path)
+
+    @staticmethod
+    def solution_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath(env.task_dir, env.config.solutions_subdir, *path)
+
+    @staticmethod
+    def executable_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath(env.task_dir, BUILD_DIR, *path)
+
+    @staticmethod
+    def data_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath(env.task_dir, env.config.data_subdir, *path)
+
+    @staticmethod
+    def generated_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath.data_path(env, GENERATED_SUBDIR, *path)
+
+    @staticmethod
+    def input_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath.data_path(env, INPUTS_SUBDIR, *path)
+
+    @staticmethod
+    def invalid_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath.data_path(env, INVALID_OUTPUTS_SUBDIR, *path)
+
+    @staticmethod
+    def output_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath.data_path(env, OUTPUTS_SUBDIR, *path)
+
+    @staticmethod
+    def output_file(env: Env, input_name: str, solution: str) -> "TaskPath":
+        input_name = os.path.splitext(os.path.basename(input_name))[0]
+        solution = os.path.basename(solution)
+        return TaskPath.output_path(env, f"{input_name}.{solution}.out")
+
+    @staticmethod
+    def sanitized_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath.data_path(env, SANITIZED_SUBDIR, *path)
+
+    @staticmethod
+    def sanitized_file(env: Env, name: str) -> "TaskPath":
+        name = os.path.basename(name)
+        return TaskPath.sanitized_path(env, f"{name}.clean")
+
+    @staticmethod
+    def log_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath.data_path(env, LOG_SUBDIR, *path)
+
+    @staticmethod
+    def points_file(env: Env, name: str) -> "TaskPath":
+        name = os.path.splitext(name)[0]
+        return TaskPath.log_path(env, f"{name}.points")
+
+    @staticmethod
+    def log_file(env: Env, name: str, program: str) -> "TaskPath":
+        name = os.path.splitext(os.path.basename(name))[0]
+        program = os.path.basename(program)
+        return TaskPath.log_path(env, f"{name}.{program}.log")

--- a/pisek/paths.py
+++ b/pisek/paths.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
+import yaml
 
 from pisek.env import Env
 
@@ -109,6 +110,11 @@ class TaskPath:
         return TaskPath.data_path(env, INVALID_OUTPUTS_SUBDIR, *path)
 
     @staticmethod
+    def invalid_file(env: Env, name: str, seed: int) -> "TaskPath":
+        name = os.path.splitext(name)[0]
+        return TaskPath.invalid_path(env, f"{name}.{seed:x}.invalid")
+
+    @staticmethod
     def output_path(env: Env, *path: str) -> "TaskPath":
         return TaskPath.data_path(env, OUTPUTS_SUBDIR, *path)
 
@@ -141,3 +147,16 @@ class TaskPath:
         name = os.path.splitext(os.path.basename(name))[0]
         program = os.path.basename(program)
         return TaskPath.log_path(env, f"{name}.{program}.log")
+
+
+def task_path_representer(dumper, task_path: TaskPath):
+    return dumper.represent_sequence("!TaskPath", [task_path._task_path, task_path.relpath])
+
+
+def task_path_constructor(loader, value):
+    (task_dir, path) = loader.construct_sequence(value)
+    return TaskPath(task_dir, path)
+
+
+yaml.add_representer(TaskPath, task_path_representer)
+yaml.add_constructor("!TaskPath", task_path_constructor)

--- a/pisek/paths.py
+++ b/pisek/paths.py
@@ -32,7 +32,7 @@ LOG_SUBDIR = "log/"
 class TaskPath:
     """Class representing a path to task file."""
 
-    def __init__(self, task_path, *path: str):
+    def __init__(self, task_path: str, *path: str):
         joined_path = os.path.normpath(os.path.join(*path))
         self._task_path = task_path
         self.fullpath = os.path.join(task_path, joined_path)

--- a/pisek/paths.py
+++ b/pisek/paths.py
@@ -33,6 +33,7 @@ class TaskPath:
 
     def __init__(self, task_path, *path: str):
         joined_path = os.path.normpath(os.path.join(*path))
+        self._task_path = task_path
         self.fullpath = os.path.join(task_path, joined_path)
         self.relpath = joined_path
         self.name = os.path.basename(joined_path)
@@ -52,13 +53,24 @@ class TaskPath:
                     f"Invalid format specifier '{__format_spec}' for object of type '{self.__class__.__name__}'"
                 )
 
+    def __eq__(self, other_path: "TaskPath") -> bool:
+        return self.relpath == other_path.relpath
+
+    def replace_suffix(self, new_suffix: str) -> "TaskPath":
+        path = os.path.splitext(self.relpath)[0] + new_suffix
+        return TaskPath(self._task_path, path)
+
     @staticmethod
     def base_path(env: Env, *path: str) -> "TaskPath":
         return TaskPath(env.task_dir, *path)
 
     @staticmethod
-    def from_abspath(env: Env, path: str) -> "TaskPath":
-        return TaskPath.base_path(env, os.path.relpath(path, env.task_dir))
+    def from_abspath(env: Env, *path: str) -> "TaskPath":
+        return TaskPath.base_path(env, os.path.relpath(os.path.join(*path), env.task_dir))
+
+    @staticmethod
+    def static_path(env: Env, *path: str) -> "TaskPath":
+        return TaskPath(env.task_dir, env.config.static_subdir, *path)
 
     @staticmethod
     def solution_path(env: Env, *path: str) -> "TaskPath":

--- a/pisek/self_tests/test_cms.py
+++ b/pisek/self_tests/test_cms.py
@@ -3,9 +3,9 @@ import shutil
 
 import unittest
 
+from pisek.paths import GENERATED_SUBDIR
 from pisek.self_tests.util import TestFixtureVariant, overwrite_file
 from pisek.task_config import TaskConfig
-from pisek.jobs.parts.task_job import GENERATED_SUBDIR
 
 
 class TestSumCMS(TestFixtureVariant):

--- a/pisek/visualize.py
+++ b/pisek/visualize.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from collections import namedtuple
+import fnmatch
 import json
 from math import ceil
 import os
@@ -59,7 +60,7 @@ def group_by_subtask(
 
 
 def in_subtask(name: str, subtask: SubtaskConfig):
-    return len(TaskHelper.filter_by_globs(subtask.all_globs, [name + ".in"])) == 1
+    return any(fnmatch.fnmatch(f"{name}.in", g) for g in subtask.all_globs)
 
 
 def evaluate_solution(


### PR DESCRIPTION
Rewrote how we represent paths. Now instead of path string we have ``TaskPath`` instance that contains:
- Full path (for file operations)
- Path relative to task directory (for failures)
- Basename (for job names)

This way we can always choose which form we want to show instead of constant transformations