### PR TITLE
CMS: Make -d default to the only dataset

### DIFF
--- a/pisek/__main__.py
+++ b/pisek/__main__.py
@@ -238,7 +238,7 @@ def main(argv):
             "--dataset",
             "-d",
             type=str,
-            required=True,
+            required=False,
             help="Use the dataset with the description DESCRIPTION.",
         )
 

--- a/pisek/cms/dataset.py
+++ b/pisek/cms/dataset.py
@@ -213,7 +213,7 @@ def get_dataset(session: Session, task: Task, description: Optional[str]) -> Dat
 
         if len(datasets) > 2:
             raise RuntimeError(
-                f'The task has multiple datasets: {", ".join(d.description for d in datasets)}'
+                f"The task has multiple datasets: {', '.join(d.description for d in datasets)}"
             )
         else:
             return datasets[0]


### PR DESCRIPTION
This PR allows you to omit the `-d`/`--dataset` flag for selecting a dataset when there is only one dataset.
When there are multiple datasets, it will also print their descriptions, allowing you to copy one of them.

This makes it way easier to use `check` and `testing-log`.
