### PR TITLE
Generate testing log even if solution fails

### DIFF
--- a/pisek/jobs/jobs.py
+++ b/pisek/jobs/jobs.py
@@ -72,6 +72,7 @@ class CaptureInitParams:
 class PipelineItem(ABC):
     """Generic PipelineItem with state and dependencies."""
 
+    _env: Env
     run_always: bool = False  # Runs even if prerequisites failed
 
     def __init__(self, name: str) -> None:
@@ -362,7 +363,7 @@ class JobManager(PipelineItem):
             else:
                 self.state = State.succeeded
 
-            self.result = self._compute_result()
+        self.result = self._compute_result()
 
         super().finish()
         return self._get_status()

--- a/pisek/jobs/jobs.py
+++ b/pisek/jobs/jobs.py
@@ -27,6 +27,7 @@ import os.path
 from pisek.jobs.cache import Cache, CacheEntry
 from pisek.env.env import Env
 from pisek.utils.paths import TaskPath
+from pisek.utils.terminal import colored_env
 
 
 class State(Enum):
@@ -88,6 +89,12 @@ class PipelineItem(ABC):
         """Prints text to stdout/stderr."""
         self.dirty = True
         (sys.stderr if stderr else sys.stdout).write(msg + end)
+
+    def _warn(self, msg: str) -> None:
+        if self._env.strict:
+            raise PipelineItemFailure(msg)
+        else:
+            self._print(colored_env(msg, "yellow", self._env))
 
     def _fail(self, failure: PipelineItemFailure) -> None:
         """End this job in failure."""

--- a/pisek/jobs/jobs.py
+++ b/pisek/jobs/jobs.py
@@ -107,7 +107,7 @@ class PipelineItem(ABC):
 
     def _check_prerequisites(self) -> None:
         """Checks if all prerequisites are finished raises error otherwise."""
-        if self.prerequisites > 0:
+        if not self.run_always and self.prerequisites > 0:
             raise RuntimeError(
                 f"{self.__class__.__name__} {self.name} prerequisites not finished ({self.prerequisites} remaining)."
             )

--- a/pisek/jobs/parts/testing_log.py
+++ b/pisek/jobs/parts/testing_log.py
@@ -67,6 +67,9 @@ class CreateTestingLog(TaskJobManager):
                     }
                 )
 
+        if len(solutions) == 0:
+            raise PipelineItemFailure("No solution was tested.")
+
         if len(solutions) < len(self._env.config.solutions):
             self._warn("Not all solutions were tested.")
         if warn_skipped:

--- a/pisek/jobs/parts/testing_log.py
+++ b/pisek/jobs/parts/testing_log.py
@@ -29,6 +29,8 @@ TESTING_LOG = "testing_log.json"
 
 
 class CreateTestingLog(TaskJobManager):
+    run_always: bool = True
+
     def __init__(self):
         super().__init__(f"Creating testing log")
 

--- a/pisek/jobs/parts/testing_log.py
+++ b/pisek/jobs/parts/testing_log.py
@@ -65,17 +65,10 @@ class CreateTestingLog(TaskJobManager):
                     }
                 )
 
-        warn_msg = None
-        if len(solutions) < len(self._env.solutions):
-            warn_msg = "Not all solutions were tested."
-        elif warn_skipped:
-            warn_msg = "Not all inputs were tested. For testing them use --all-inputs."
-
-        if warn_msg is not None:
-            if self._env.strict:
-                raise PipelineItemFailure(warn_msg)
-            else:
-                self._print(colored_env(warn_msg, "yellow", self._env))
+        if len(solutions) < len(self._env.config.solutions):
+            self._warn("Not all solutions were tested.")
+        if warn_skipped:
+            self._warn("Not all inputs were tested. For testing them use --all-inputs.")
 
         with open(TaskPath(TESTING_LOG).path, "w") as f:
             json.dump(log, f, indent=4)

--- a/pisek/jobs/parts/testing_log.py
+++ b/pisek/jobs/parts/testing_log.py
@@ -42,7 +42,9 @@ class CreateTestingLog(TaskJobManager):
         solutions: set[str] = set()
         warn_skipped: bool = False
         for name, data in self.prerequisites_results.items():
-            if not name.startswith(SOLUTION_MAN_CODE):
+            if not name.startswith(SOLUTION_MAN_CODE) or not any(
+                data["results"].values()
+            ):
                 continue
 
             solution = name[len(SOLUTION_MAN_CODE) :]


### PR DESCRIPTION
Generalized job core for `Job`s running always. `JobManger`s have to generate result even if `JobManager._evaluate` fails.

Fixes #152.

