### PR TITLE
DataChecking: Support in_format and out_format keys

### DIFF
--- a/fixtures/sum_cms/gen_no_lf.py
+++ b/fixtures/sum_cms/gen_no_lf.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import random
+import sys
+import os
+
+test_dir = sys.argv[1]
+os.makedirs(test_dir, exist_ok=True)
+
+POSITIVE_ONLY = [True, False, False]
+MAX_ABS = [int(1e9), int(1e9), int(1e18)]
+
+random.seed(123)
+
+print("Generating...", file=sys.stderr)
+for subtask_i, (positive_only, max_abs) in enumerate(zip(POSITIVE_ONLY, MAX_ABS)):
+    for ti in range(5):
+        a = random.randint(-max_abs, max_abs)
+        b = random.randint(-max_abs, max_abs)
+        if positive_only:
+            a = abs(a)
+            b = abs(b)
+
+        test_filename = "{:0>2}_{:0>2}.in".format(subtask_i + 1, ti + 1)
+
+        with open(os.path.join(test_dir, test_filename), "w") as f:
+            f.write("{} {}".format(a, b))

--- a/fixtures/sum_cms/solve_no_lf.py
+++ b/fixtures/sum_cms/solve_no_lf.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+a, b = [int(x) for x in input().split()]
+print(a + b, end="")

--- a/fixtures/sum_kasiopea/config
+++ b/fixtures/sum_kasiopea/config
@@ -12,7 +12,6 @@ in_mode=online
 in_gen=gen
 checker=check
 out_mode=solve
-out_format=text
 online_validity=360
 out_check=diff
 

--- a/pisek/config/config_types.py
+++ b/pisek/config/config_types.py
@@ -28,6 +28,11 @@ class JudgeType(StrEnum):
     opendata_v1 = "opendata-v1"
 
 
+class FormatType(StrEnum):
+    text = auto()
+    binary = auto()
+
+
 class Scoring(StrEnum):
     equal = auto()
     min = auto()

--- a/pisek/config/config_types.py
+++ b/pisek/config/config_types.py
@@ -28,7 +28,7 @@ class JudgeType(StrEnum):
     opendata_v1 = "opendata-v1"
 
 
-class FormatType(StrEnum):
+class DataFormat(StrEnum):
     text = auto()
     binary = auto()
 

--- a/pisek/config/global-defaults
+++ b/pisek/config/global-defaults
@@ -9,6 +9,8 @@ data_subdir=data/
 checker=
 judge_needs_in=1
 judge_needs_out=1
+in_format=text
+out_format=text
 stub=
 headers=
 

--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -38,6 +38,7 @@ from pisek.config.config_types import (
     TaskType,
     OutCheck,
     JudgeType,
+    FormatType,
     Scoring,
     ProgramType,
     CMSFeedbackLevel,
@@ -90,6 +91,9 @@ class TaskConfig(BaseEnv):
     judge_type: Optional[JudgeType]
     judge_needs_in: bool
     judge_needs_out: bool
+
+    in_format: FormatType
+    out_format: FormatType
 
     stub: OptionalStr
     headers: ListStr
@@ -150,6 +154,8 @@ class TaskConfig(BaseEnv):
             ("tests", "in_gen"),
             ("tests", "checker"),
             ("tests", "out_check"),
+            ("tests", "in_format"),
+            ("tests", "out_format"),
             ("tests", "stub"),
             ("tests", "headers"),
         ]

--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -38,7 +38,7 @@ from pisek.config.config_types import (
     TaskType,
     OutCheck,
     JudgeType,
-    FormatType,
+    DataFormat,
     Scoring,
     ProgramType,
     CMSFeedbackLevel,
@@ -92,8 +92,8 @@ class TaskConfig(BaseEnv):
     judge_needs_in: bool
     judge_needs_out: bool
 
-    in_format: FormatType
-    out_format: FormatType
+    in_format: DataFormat
+    out_format: DataFormat
 
     stub: OptionalStr
     headers: ListStr

--- a/pisek/config/update_config.py
+++ b/pisek/config/update_config.py
@@ -186,7 +186,6 @@ def update_to_v3(config: ConfigParser, task_path: str) -> None:
         ("task", "tests"),
         ("tests", "in_mode"),
         ("tests", "out_mode"),
-        ("tests", "out_format"),
         ("tests", "online_validity"),
     ]
     for section, key in IGNORED_KEYS:

--- a/pisek/jobs/parts/data.py
+++ b/pisek/jobs/parts/data.py
@@ -17,6 +17,7 @@
 import re
 from typing import Any, Callable
 
+from pisek.config.config_types import FormatType
 from pisek.jobs.jobs import Job, PipelineItemFailure
 from pisek.env.env import Env
 from pisek.utils.paths import TaskPath
@@ -182,12 +183,16 @@ class DataCheckingManager(TaskJobManager):
                     + outs[Verdict.wrong_answer]
                 )
         for inp in inputs:
-            jobs.append(IsClean(self._env, inp))
+            if self._env.config.in_format == FormatType.text:
+                jobs.append(IsClean(self._env, inp))
+
             if self._env.config.limits.input_max_size != 0:
                 jobs.append(InputSmall(self._env, inp))
 
         for out in outputs:
-            jobs.append(IsClean(self._env, out))
+            if self._env.config.out_format == FormatType.text:
+                jobs.append(IsClean(self._env, out))
+
             if self._env.config.limits.output_max_size != 0:
                 jobs.append(OutputSmall(self._env, out))
 

--- a/pisek/jobs/parts/data.py
+++ b/pisek/jobs/parts/data.py
@@ -17,7 +17,7 @@
 import re
 from typing import Any, Callable
 
-from pisek.config.config_types import FormatType
+from pisek.config.config_types import DataFormat
 from pisek.jobs.jobs import Job, PipelineItemFailure
 from pisek.env.env import Env
 from pisek.utils.paths import TaskPath
@@ -183,14 +183,14 @@ class DataCheckingManager(TaskJobManager):
                     + outs[Verdict.wrong_answer]
                 )
         for inp in inputs:
-            if self._env.config.in_format == FormatType.text:
+            if self._env.config.in_format == DataFormat.text:
                 jobs.append(IsClean(self._env, inp))
 
             if self._env.config.limits.input_max_size != 0:
                 jobs.append(InputSmall(self._env, inp))
 
         for out in outputs:
-            if self._env.config.out_format == FormatType.text:
+            if self._env.config.out_format == DataFormat.text:
                 jobs.append(IsClean(self._env, out))
 
             if self._env.config.limits.output_max_size != 0:

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -109,7 +109,7 @@ class TestStrictChecker(TestSumCMS):
         overwrite_file(self.task_dir, "check.py", "check_strict.py")
 
 
-class TestDirtySamle(TestSumCMS):
+class TestDirtySample(TestSumCMS):
     """Sample without newline at the end."""
 
     def expecting_success(self):
@@ -119,6 +119,64 @@ class TestDirtySamle(TestSumCMS):
         sample = ["3", "1 2", "-8 5", "0 0"]
         with open(os.path.join(self.task_dir, "sample.in"), "w") as f:
             f.write("\n".join(sample))
+
+
+class TestNoLFInTextInput(TestSumCMS):
+    """Input without newline at the end with in_format=text."""
+
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        def modification_fn(raw_config):
+            raw_config["tests"]["in_gen"] = "gen_no_lf"
+            raw_config["tests"]["checker"] = ""
+
+        modify_config(self.task_dir, modification_fn)
+
+
+class TestNoLFInBinaryInput(TestSumCMS):
+    """Input without newline at the end with in_format=binary."""
+
+    def expecting_success(self):
+        return True
+
+    def modify_task(self):
+        def modification_fn(raw_config):
+            raw_config["tests"]["in_format"] = "binary"
+            raw_config["tests"]["in_gen"] = "gen_no_lf"
+            raw_config["tests"]["checker"] = ""
+
+        modify_config(self.task_dir, modification_fn)
+
+
+class TestNoLFInTextOutput(TestSumCMS):
+    """Output without newline at the end with out_format=text."""
+
+    def expecting_success(self):
+        return False
+
+    def modify_task(self):
+        def modification_fn(raw_config):
+            raw_config["solution_solve"]["source"] = "solve_no_lf"
+            raw_config["tests"]["checker"] = ""
+
+        modify_config(self.task_dir, modification_fn)
+
+
+class TestNoLFInBinaryOutput(TestSumCMS):
+    """Output without newline at the end with out_format=binary."""
+
+    def expecting_success(self):
+        return True
+
+    def modify_task(self):
+        def modification_fn(raw_config):
+            raw_config["tests"]["out_format"] = "binary"
+            raw_config["solution_solve"]["source"] = "solve_no_lf"
+            raw_config["tests"]["checker"] = ""
+
+        modify_config(self.task_dir, modification_fn)
 
 
 class TestGuess(TestFixtureVariant):

--- a/tests/test_kasiopea.py
+++ b/tests/test_kasiopea.py
@@ -217,7 +217,7 @@ class TestStrictChecker(TestSumKasiopea):
         overwrite_file(self.task_dir, "check.py", "check_strict.py")
 
 
-class TestDirtySamle(TestSumKasiopea):
+class TestDirtySample(TestSumKasiopea):
     """Sample without newline at the end."""
 
     def expecting_success(self):


### PR DESCRIPTION
Adds support for the `in_format` and `out_format` keys, which can be set to `text` or `binary`. Setting the correct key to `binary` will stop pisek from checking if the relevant files are UNIX text files and contain valid ASCII chars.

Resolves #169.
