### PR TITLE
TaskConfig: Move `stub` and `headers` to `all_solutions`

### DIFF
--- a/config-v3-documentation
+++ b/config-v3-documentation
@@ -85,18 +85,6 @@ judge_needs_out=0
 # Set to 1 if judge needs input/output
 # Defaults to 1
 
-stub=src/stub
-# Only for C/C++ CMS tasks
-# Link each solution with given program (without suffix)
-# Used commonly for interactive tasks
-# TODO: Move to better section
-
-headers=src/blecha.h
-# Only for C/C++ CMS tasks
-# Allow each solution to include the given headers
-# Used commonly for interactive tasks
-# TODO: Move to better section
-
 [test01]
 # Section for each subtask (indexed from one)
 # Keys default to [all_tests] keys if test is not set
@@ -176,6 +164,19 @@ points=X
 points_above=X
 points_below=X
 subtasks=@auto
+
+# There are also keys that are specific to [all_solutions]
+# and cannot be configured on a per solution basis:
+
+stub=src/stub
+# Only for C/C++ CMS tasks
+# Link each solution with given program (without suffix)
+# Used commonly for interactive tasks
+
+headers=src/blecha.h
+# Only for C/C++ CMS tasks
+# Allow each solution to include the given headers
+# Used commonly for interactive tasks
 
 [limits]
 # Resource limits for various programs: all of them are called KEY_LIMIT,

--- a/fixtures/guess/config
+++ b/fixtures/guess/config
@@ -17,15 +17,15 @@ in_gen=src/gen
 
 # checker=check
 
-# The important line:
-stub=src/stub
-headers=src/guess.h
-
 out_check=judge
 out_judge=src/judge
 judge_type=cms
 judge_needs_in=1
 judge_needs_out=0
+
+[all_solutions]
+stub=src/stub
+headers=src/guess.h
 
 [test01]
 name=Subtask A

--- a/pisek/config/cms-defaults
+++ b/pisek/config/cms-defaults
@@ -14,8 +14,6 @@ checker=
 judge_type=cms
 judge_needs_in=1
 judge_needs_out=1
-stub=
-headers=
 
 [all_tests]
 name=@auto 
@@ -35,6 +33,8 @@ points=X
 points_above=X
 points_below=X
 subtasks=@auto
+stub=
+headers=
 
 [limits]
 tool_time_limit=0

--- a/pisek/config/global-defaults
+++ b/pisek/config/global-defaults
@@ -11,8 +11,6 @@ judge_needs_in=1
 judge_needs_out=1
 in_format=text
 out_format=text
-stub=
-headers=
 
 [all_tests]
 name=@auto 
@@ -32,6 +30,8 @@ points=X
 points_above=X
 points_below=X
 subtasks=@auto
+stub=
+headers=
 
 [limits]
 tool_time_limit=0

--- a/pisek/config/kasiopea-defaults
+++ b/pisek/config/kasiopea-defaults
@@ -14,8 +14,6 @@ checker=
 judge_type=opendata-v1
 judge_needs_in=1
 judge_needs_out=1
-stub=
-headers=
 
 [all_tests]
 name=@auto 
@@ -35,6 +33,8 @@ points=X
 points_above=X
 points_below=X
 subtasks=@auto
+stub=
+headers=
 
 [limits]
 tool_time_limit=0

--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -156,8 +156,8 @@ class TaskConfig(BaseEnv):
             ("tests", "out_check"),
             ("tests", "in_format"),
             ("tests", "out_format"),
-            ("tests", "stub"),
-            ("tests", "headers"),
+            ("all_solutions", "stub"),
+            ("all_solutions", "headers"),
         ]
         JUDGE_KEYS = [
             ("out_judge", None),

--- a/pisek/config/update_config.py
+++ b/pisek/config/update_config.py
@@ -28,6 +28,15 @@ def rename_key(config: ConfigParser, section: str, key_from: str, key_to: str):
         del config[section][key_from]
 
 
+def move_key(config: ConfigParser, key: str, section_from: str, section_to: str):
+    if key in config[section_from]:
+        if section_to not in config:
+            config.add_section("all_solutions")
+
+        config[section_to][key] = config[section_from][key]
+        del config[section_from][key]
+
+
 def maybe_delete_key(config: ConfigParser, section: str, key: str):
     if section in config and key in config[section]:
         del config[section][key]
@@ -181,6 +190,9 @@ def update_to_v3(config: ConfigParser, task_path: str) -> None:
             "limits", f"{program_type}_clock_limit", fallback="360"
         )
         maybe_delete_key(config, "limits", f"{program_type}_clock_limit")
+
+    move_key(config, "stub", "tests", "all_solutions")
+    move_key(config, "headers", "tests", "all_solutions")
 
     IGNORED_KEYS = [
         ("task", "tests"),


### PR DESCRIPTION
Moves the `stub` and `headers` keys for `[tests]` to `[all_solutions]`.

Resolved #171.