### PR TITLE
Add support for faster whitespace tolerant judge

### DIFF
--- a/config-v2-documentation
+++ b/config-v2-documentation
@@ -55,6 +55,7 @@ checker=check
 out_check=judge
 # Describes how to check outputs
 #   - diff: checks that contestant output equals correct output (ignores whitespace) (default)
+#   - tokens: uses a fast, versatile file equality checker (ignores whitespace)
 #   - judge: if there can be multiple solutions, checks with program (called 'judge')
 # In communication, only judge is allowed
 

--- a/config-v2-documentation
+++ b/config-v2-documentation
@@ -69,6 +69,25 @@ judge_needs_out=0
 # Set to 1 if judge needs input/output
 # Defaults to 1
 
+tokens_ignore_newlines=0
+# Only for out_check=tokens
+# If set to 1, newline characters will be ignored when checking the output,
+# as if they were any other whitespace characters
+# By default, newline characters are only ignored at the end of the file
+
+tokens_ignore_case=0
+# Only for out_check=tokens
+# If set to 1, ASCII characters will be compared in a case-insensitive manner
+
+tokens_float_rel_error=0.00001
+tokens_float_abs_error=1e-30
+# Only for out_check=tokens
+# When these options are specified, floating-point numbers
+# will be parsed and compared with a given error margin
+# Any tokens that can't be parsed as a float will be compared character-by-character
+# If used, both of these options must be specified
+# Set both options to X to disable
+
 stub=src/stub
 # Only for C/C++ CMS tasks
 # Link each solution with given program (without suffix)

--- a/config-v2-documentation
+++ b/config-v2-documentation
@@ -86,7 +86,7 @@ tokens_float_abs_error=1e-30
 # will be parsed and compared with a given error margin
 # Any tokens that can't be parsed as a float will be compared character-by-character
 # If used, both of these options must be specified
-# Set both options to X to disable
+# To explicitly disable float checking, set both options to the empty string
 
 stub=src/stub
 # Only for C/C++ CMS tasks

--- a/config-v2-documentation
+++ b/config-v2-documentation
@@ -54,7 +54,7 @@ checker=check
 
 out_check=judge
 # Describes how to check outputs
-#   - diff: checks that contestant output equals correct output (ignores whitespace) (default)
+#   - diff: checks that contestant output equals correct output (ignores whitespace)
 #   - tokens: uses a fast, versatile file equality checker (ignores whitespace)
 #   - judge: if there can be multiple solutions, checks with program (called 'judge')
 # In communication, only judge is allowed

--- a/config-v3-documentation
+++ b/config-v3-documentation
@@ -103,7 +103,7 @@ tokens_float_abs_error=1e-30
 # will be parsed and compared with a given error margin
 # Any tokens that can't be parsed as a float will be compared character-by-character
 # If used, both of these options must be specified
-# Set both options to X to disable
+# To explicitly disable float checking, set both options to the empty string
 
 [test01]
 # Section for each subtask (indexed from one)

--- a/config-v3-documentation
+++ b/config-v3-documentation
@@ -62,6 +62,7 @@ checker=check
 out_check=judge
 # Describes how to check outputs
 #   - diff: checks that contestant output equals correct output (ignores whitespace) (default)
+#   - tokens: uses a fast, versatile file equality checker (ignores whitespace)
 #   - judge: if there can be multiple solutions, checks with program (called 'judge')
 # In communication, only judge is allowed
 

--- a/config-v3-documentation
+++ b/config-v3-documentation
@@ -61,7 +61,7 @@ checker=check
 
 out_check=judge
 # Describes how to check outputs
-#   - diff: checks that contestant output equals correct output (ignores whitespace) (default)
+#   - diff: checks that contestant output equals correct output (ignores whitespace)
 #   - tokens: uses a fast, versatile file equality checker (ignores whitespace)
 #   - judge: if there can be multiple solutions, checks with program (called 'judge')
 # In communication, only judge is allowed

--- a/config-v3-documentation
+++ b/config-v3-documentation
@@ -86,6 +86,25 @@ judge_needs_out=0
 # Set to 1 if judge needs input/output
 # Defaults to 1
 
+tokens_ignore_newlines=0
+# Only for out_check=tokens
+# If set to 1, newline characters will be ignored when checking the output,
+# as if they were any other whitespace characters
+# By default, newline characters are only ignored at the end of the file
+
+tokens_ignore_case=0
+# Only for out_check=tokens
+# If set to 1, ASCII characters will be compared in a case-insensitive manner
+
+tokens_float_rel_error=0.00001
+tokens_float_abs_error=1e-30
+# Only for out_check=tokens
+# When these options are specified, floating-point numbers
+# will be parsed and compared with a given error margin
+# Any tokens that can't be parsed as a float will be compared character-by-character
+# If used, both of these options must be specified
+# Set both options to X to disable
+
 [test01]
 # Section for each subtask (indexed from one)
 # Keys default to [all_tests] keys if test is not set

--- a/fixtures/sum_kasiopea/config
+++ b/fixtures/sum_kasiopea/config
@@ -13,7 +13,7 @@ in_gen=gen
 checker=check
 out_mode=solve
 online_validity=360
-out_check=diff
+out_check=tokens
 
 [test01]
 name=Easy input

--- a/pisek/config/config_types.py
+++ b/pisek/config/config_types.py
@@ -20,6 +20,7 @@ class TaskType(StrEnum):
 
 class OutCheck(StrEnum):
     diff = auto()
+    tokens = auto()
     judge = auto()
 
 

--- a/pisek/config/global-defaults
+++ b/pisek/config/global-defaults
@@ -9,6 +9,10 @@ data_subdir=data/
 checker=
 judge_needs_in=1
 judge_needs_out=1
+tokens_ignore_newlines=0
+tokens_ignore_case=0
+tokens_float_rel_error=X
+tokens_float_abs_error=X
 in_format=text
 out_format=text
 

--- a/pisek/config/global-defaults
+++ b/pisek/config/global-defaults
@@ -11,8 +11,8 @@ judge_needs_in=1
 judge_needs_out=1
 tokens_ignore_newlines=0
 tokens_ignore_case=0
-tokens_float_rel_error=X
-tokens_float_abs_error=X
+tokens_float_rel_error=
+tokens_float_abs_error=
 in_format=text
 out_format=text
 

--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -51,11 +51,9 @@ from pisek.jobs.parts.solution_result import SUBTASK_SPEC
 MaybeInt = Annotated[
     Optional[int], BeforeValidator(lambda i: (None if i == "X" else i))
 ]
-MaybeFloat = Annotated[
-    Optional[float], BeforeValidator(lambda i: (None if i == "X" else i))
-]
 ListStr = Annotated[list[str], BeforeValidator(lambda s: s.split())]
 OptionalStr = Annotated[Optional[str], BeforeValidator(lambda s: s or None)]
+OptionalFloat = Annotated[Optional[float], BeforeValidator(lambda s: s or None)]
 
 MISSING_VALIDATION_CONTEXT = "Missing validation context."
 
@@ -96,8 +94,8 @@ class TaskConfig(BaseEnv):
     judge_needs_out: bool
     tokens_ignore_newlines: bool
     tokens_ignore_case: bool
-    tokens_float_rel_error: MaybeFloat
-    tokens_float_abs_error: MaybeFloat
+    tokens_float_rel_error: OptionalFloat
+    tokens_float_abs_error: OptionalFloat
 
     in_format: DataFormat
     out_format: DataFormat
@@ -237,8 +235,8 @@ class TaskConfig(BaseEnv):
                 {"task_type": self.task_type, "out_check": self.out_check},
             )
 
-        if (self.tokens_float_abs_error == None) != (
-            self.tokens_float_rel_error == None
+        if (self.tokens_float_abs_error is not None) != (
+            self.tokens_float_rel_error is not None
         ):
             raise PydanticCustomError(
                 "tokens_errors_must_be_set_together",

--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -51,6 +51,9 @@ from pisek.jobs.parts.solution_result import SUBTASK_SPEC
 MaybeInt = Annotated[
     Optional[int], BeforeValidator(lambda i: (None if i == "X" else i))
 ]
+MaybeFloat = Annotated[
+    Optional[float], BeforeValidator(lambda i: (None if i == "X" else i))
+]
 ListStr = Annotated[list[str], BeforeValidator(lambda s: s.split())]
 OptionalStr = Annotated[Optional[str], BeforeValidator(lambda s: s or None)]
 
@@ -91,6 +94,10 @@ class TaskConfig(BaseEnv):
     judge_type: Optional[JudgeType]
     judge_needs_in: bool
     judge_needs_out: bool
+    tokens_ignore_newlines: bool
+    tokens_ignore_case: bool
+    tokens_float_rel_error: MaybeFloat
+    tokens_float_abs_error: MaybeFloat
 
     in_format: DataFormat
     out_format: DataFormat
@@ -159,19 +166,23 @@ class TaskConfig(BaseEnv):
             ("all_solutions", "stub"),
             ("all_solutions", "headers"),
         ]
-        JUDGE_KEYS = [
-            ("out_judge", None),
-            ("judge_type", None),
-            ("judge_needs_in", "0"),
-            ("judge_needs_out", "1"),
+        OUT_CHECK_SPECIFIC_KEYS = [
+            ("judge", "out_judge", None),
+            ("judge", "judge_type", None),
+            ("judge", "judge_needs_in", "0"),
+            ("judge", "judge_needs_out", "1"),
+            ("tokens", "tokens_ignore_newlines", "0"),
+            ("tokens", "tokens_ignore_case", "0"),
+            ("tokens", "tokens_float_rel_error", None),
+            ("tokens", "tokens_float_abs_error", None),
         ]
         args: dict[str, Any] = {
             key: configs.get(section, key) for section, key in GLOBAL_KEYS
         }
 
         # Load judge specific keys
-        for key, default in JUDGE_KEYS:
-            if args["out_check"].value == "judge":
+        for out_check, key, default in OUT_CHECK_SPECIFIC_KEYS:
+            if args["out_check"].value == out_check:
                 args[key] = configs.get("tests", key)
             else:
                 args[key] = ConfigValue(default, "_internal", "tests", key, True)
@@ -224,6 +235,18 @@ class TaskConfig(BaseEnv):
                 "communication_must_have_judge",
                 "For communication task 'out_check' must be 'judge'",
                 {"task_type": self.task_type, "out_check": self.out_check},
+            )
+
+        if (self.tokens_float_abs_error == None) != (
+            self.tokens_float_rel_error == None
+        ):
+            raise PydanticCustomError(
+                "tokens_errors_must_be_set_together",
+                "Both types of floating point error must be set together",
+                {
+                    "tokens_float_abs_error": self.tokens_float_abs_error,
+                    "tokens_float_rel_error": self.tokens_float_rel_error,
+                },
             )
 
         primary = [name for name, sol in self.solutions.items() if sol.primary]

--- a/pisek/jobs/parts/judge.py
+++ b/pisek/jobs/parts/judge.py
@@ -262,7 +262,7 @@ class RunJudge(ProgramsJob):
                 + tab(
                     self._format_run_result(
                         judge_rr,
-                        status=isinstance(self, RunDiffJudge),
+                        status=isinstance(self, RunDiffJudge | RunTokenJudge),
                         stderr_force_content=True,
                     )
                 )
@@ -424,6 +424,59 @@ class RunDiffJudge(RunBatchJudge):
             )
 
 
+class RunTokenJudge(RunBatchJudge):
+    """Judges solution output and correct output using judge-token."""
+
+    def __init__(
+        self,
+        env: Env,
+        input_: TaskPath,
+        output: TaskPath,
+        correct_output: TaskPath,
+        expected_points: Optional[float],
+    ) -> None:
+        super().__init__(
+            env=env,
+            judge_name="judge-token",
+            input_=input_,
+            output=output,
+            correct_output=correct_output,
+            expected_points=expected_points,
+        )
+
+    def _judge(self) -> SolutionResult:
+        self._access_file(self.output)
+        self._access_file(self.correct_output)
+
+        executable = TaskPath.executable_path(self._env, "judge-token")
+        flags = ["-t"]
+
+        judge = subprocess.run(
+            [executable.path, *flags, self.output.path, self.correct_output.path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        stderr = judge.stderr.decode("utf-8")
+
+        # XXX: Okay, it didn't finish in no time, but this is not meant to be used
+        rr = RunResult(
+            RunResultKind.OK,
+            judge.returncode,
+            0,
+            0,
+            status=(stderr.strip() or "Files are equivalent")
+            + f": {self.output.col(self._env)} {self.correct_output.col(self._env)}",
+        )
+
+        if judge.returncode == 42:
+            return SolutionResult(Verdict.ok, 1.0, self._solution_run_res, rr)
+        elif judge.returncode == 43:
+            return SolutionResult(Verdict.wrong_answer, 0.0, self._solution_run_res, rr)
+        else:
+            raise PipelineItemFailure(f"Token judge failed:\n{tab(stderr)}")
+
+
 class RunKasiopeaJudge(RunBatchJudge):
     """Judges solution output using judge with Kasiopea interface."""
 
@@ -532,10 +585,13 @@ def judge_job(
     get_seed: Callable[[], str],
     expected_points: Optional[float],
     env: Env,
-) -> Union[RunDiffJudge, RunKasiopeaJudge, RunCMSBatchJudge]:
+) -> Union[RunDiffJudge, RunTokenJudge, RunKasiopeaJudge, RunCMSBatchJudge]:
     """Returns JudgeJob according to contest type."""
     if env.config.out_check == OutCheck.diff:
         return RunDiffJudge(env, input_, output, correct_output, expected_points)
+
+    if env.config.out_check == OutCheck.tokens:
+        return RunTokenJudge(env, input_, output, correct_output, expected_points)
 
     if env.config.out_judge is None:
         raise RuntimeError(f"Unset judge for out_check={env.config.out_check.name}")

--- a/pisek/jobs/parts/judge.py
+++ b/pisek/jobs/parts/judge.py
@@ -451,6 +451,21 @@ class RunTokenJudge(RunBatchJudge):
         executable = TaskPath.executable_path(self._env, "judge-token")
         flags = ["-t"]
 
+        if self._env.config.tokens_ignore_newlines:
+            flags.append("-n")
+        if self._env.config.tokens_ignore_case:
+            flags.append("-i")
+        if self._env.config.tokens_float_rel_error != None:
+            flags.extend(
+                [
+                    "-r",
+                    "-e",
+                    str(self._env.config.tokens_float_rel_error),
+                    "-E",
+                    str(self._env.config.tokens_float_abs_error),
+                ]
+            )
+
         judge = subprocess.run(
             [executable.path, *flags, self.output.path, self.correct_output.path],
             stdout=subprocess.PIPE,

--- a/pisek/jobs/parts/judge.py
+++ b/pisek/jobs/parts/judge.py
@@ -44,7 +44,7 @@ class JudgeManager(TaskJobManager):
 
     def _get_jobs(self) -> list[Job]:
         jobs: list[Job] = []
-        comp = None
+        comp: Optional[Job] = None
 
         if self._env.config.out_check == OutCheck.judge:
             if self._env.config.out_judge is None:

--- a/pisek/jobs/parts/tools.py
+++ b/pisek/jobs/parts/tools.py
@@ -102,7 +102,7 @@ class PrepareTextPreprocessor(TaskJob):
 
 
 class PrepareJudgeToken(TaskJob):
-    """Compiles Text Preprocessor."""
+    """Compiles the generic token-based judge."""
 
     def __init__(self, env: Env, **kwargs) -> None:
         super().__init__(env=env, name="Prepare token judge", **kwargs)

--- a/pisek/jobs/parts/tools.py
+++ b/pisek/jobs/parts/tools.py
@@ -38,7 +38,6 @@ class ToolsManager(TaskJobManager):
         jobs: list[Job] = [
             PrepareMinibox(self._env),
             PrepareTextPreprocessor(self._env),
-            PrepareJudgeToken(self._env),
         ]
         return jobs
 
@@ -101,7 +100,7 @@ class PrepareTextPreprocessor(TaskJob):
             raise PipelineItemFailure("Text preprocessor compilation failed.")
 
 
-class PrepareJudgeToken(TaskJob):
+class PrepareTokenJudge(TaskJob):
     """Compiles the generic token-based judge."""
 
     def __init__(self, env: Env, **kwargs) -> None:

--- a/pisek/tools/judgelib/io.cc
+++ b/pisek/tools/judgelib/io.cc
@@ -1,0 +1,103 @@
+/*
+ *	I/O functions for judges
+ *
+ *	(c) 2021 Martin Mares <mj@ucw.cz>
+ *
+ *	Based on judge library from the Moe contest system by the same author.
+ *	Can be freely distributed and used under the terms of the GNU GPL v2 or later.
+ *
+ *	SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+#include <fcntl.h>
+
+using namespace std;
+
+#include "judge.h"
+
+#define BUFSIZE 65536
+
+stream::stream()
+{
+	name = NULL;
+	fd = -1;
+	buf = pos = stop = end = NULL;
+}
+
+void stream::open_fd(const char *name, int fd, bool want_close)
+{
+	const char *slash = strrchr(name, '/');
+	const char *basename = (slash ? slash+1 : name);
+	this->fd = fd;
+	this->want_close = want_close;
+	buf = (u8 *) xmalloc(BUFSIZE);
+	pos = stop = buf;
+	end = buf + BUFSIZE;
+	this->name = xstrdup(basename);
+}
+
+void stream::open_read(const char *name)
+{
+	int fd = open(name, O_RDONLY);
+	if (fd < 0)
+		die("Unable to open %s for reading: %m", name);
+	open_fd(name, fd);
+}
+
+void stream::open_write(const char *name)
+{
+	int fd = open(name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (fd < 0)
+		die("Unable to open %s for writing: %m", name);
+	open_fd(name, fd);
+}
+
+void stream::flush()
+{
+	if (stop == buf && pos > buf) {
+		u8 *p = buf;
+		int len = pos - buf;
+		while (len > 0) {
+			int cnt = write(fd, p, len);
+			if (cnt <= 0)
+				die("Error writing %s: %m", name);
+			p += cnt;
+			len -= cnt;
+		}
+	}
+	pos = buf;
+}
+
+stream::~stream()
+{
+	flush();
+	if (want_close)
+		close(fd);
+	if (name)
+		free(name);
+	if (buf)
+		free(buf);
+}
+
+int stream::refill()
+{
+	int len = read(fd, buf, BUFSIZE);
+	if (len < 0)
+		die("Error reading %s: %m", name);
+	pos = buf;
+	stop = buf + len;
+	return len;
+}
+
+int stream::getc_slow()
+{
+	return (refill() ? *pos++ : -1);
+}
+
+int stream::peekc_slow()
+{
+	return (refill() ? *pos : -1);
+}

--- a/pisek/tools/judgelib/judge-token.cc
+++ b/pisek/tools/judgelib/judge-token.cc
@@ -1,0 +1,124 @@
+/*
+ *	A judge comparing two sequences of tokens
+ *
+ *	(c) 2021 Martin Mares <mj@ucw.cz>
+ *
+ *	Based on code from the Moe contest system, which is:
+ *
+ *	(c) 2007 Martin Krulis <bobrik@matfyz.cz>
+ *	(c) 2007 Martin Mares <mj@ucw.cz>
+ *
+ *	Can be freely distributed and used under the terms of the GNU GPL v2 or later.
+ *
+ *	SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <getopt.h>
+#include <math.h>
+
+using namespace std;
+
+#include "judge.h"
+
+static bool ignore_nl, ignore_trailing_nl, ignore_case;
+static bool real_mode;
+static double rel_eps = 1e-5;
+static double abs_eps = 1e-30;
+
+static bool tokens_equal(tokenizer *t1, tokenizer *t2)
+{
+	if (real_mode) {
+		double x1, x2;
+		if (t1->to_double(&x1) && t2->to_double(&x2)) {
+			if (x1 == x2)
+				return true;
+			double eps = fabs(x2 * rel_eps);
+			if (eps < abs_eps)
+				eps = abs_eps;
+			return (fabs(x1-x2) <= eps);
+		}
+		// If they fail to convert, compare them as strings.
+	}
+	return !(ignore_case ? strcasecmp : strcmp)(t1->token, t2->token);
+}
+
+static bool trailing_nl(tokenizer *t)
+{
+	// Ignore empty lines at the end of file
+	if (t->token[0] || !ignore_trailing_nl)
+		return false;
+	t->report_lines = false;
+	return !t->get_token();
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "Usage: judge-token [<options>] <output> <correct>\n\
+\n\
+Options:\n\
+-n\t\tIgnore newlines\n\
+-t\t\tIgnore newlines at the end of file\n\
+-i\t\tIgnore differences in letter case\n\
+-r\t\tMatch tokens as real numbers and allow small differences:\n\
+-e <epsilon>\tSet maximum allowed relative error (default: %g)\n\
+-E <epsilon>\tSet maximum allowed absolute error (default: %g)\n\
+", rel_eps, abs_eps);
+	exit(1);
+}
+
+int main(int argc, char **argv)
+{
+	int opt;
+
+	while ((opt = getopt(argc, argv, "ntire:E:")) >= 0) {
+		switch (opt) {
+			case 'n':
+				ignore_nl = true;
+				break;
+			case 't':
+				ignore_trailing_nl = true;
+				break;
+			case 'i':
+				ignore_case = true;
+				break;
+			case 'r':
+				real_mode = true;
+				break;
+			case 'e':
+				rel_eps = atof(optarg);
+				break;
+			case 'E':
+				abs_eps = atof(optarg);
+				break;
+			default:
+				usage();
+		}
+	}
+	if (optind + 2 != argc)
+		usage();
+
+	tokenizer t1(argv[optind]);
+	tokenizer t2(argv[optind+1]);
+	if (!ignore_nl)
+		t1.report_lines = t2.report_lines = true;
+
+	for (;;) {
+		char *a = t1.get_token(), *b = t2.get_token();
+		if (!a) {
+			if (b && !trailing_nl(&t2))
+				t1.reject("Ends too early");
+			break;
+		} else if (!b) {
+			if (a && !trailing_nl(&t1))
+				t2.reject("Garbage at the end");
+			break;
+		} else if (!tokens_equal(&t1, &t2)) {
+			t1.reject("Found <%s>, expected <%s>", a, b);
+		}
+	}
+
+	return 42;
+}

--- a/pisek/tools/judgelib/judge.h
+++ b/pisek/tools/judgelib/judge.h
@@ -1,0 +1,172 @@
+/*
+ *	A simple library for judges
+ *
+ *	(c) 2021-2022 Martin Mares <mj@ucw.cz>
+ *
+ *	Based on judge library from the Moe contest system by the same author.
+ */
+
+#ifndef JUDGE_H
+#define JUDGE_H
+
+#include <cassert>
+#include <cstdint>
+#include <sys/types.h>
+
+/* Types */
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+typedef int8_t s8;
+typedef int16_t s16;
+typedef int32_t s32;
+typedef int64_t s64;
+
+typedef unsigned int uint;
+
+/* GCC extensions */
+
+#ifdef __GNUC__
+#define NONRET __attribute__((noreturn))
+#else
+#define NONRET
+#endif
+
+/* Return codes */
+
+enum judge_exit_code {
+	EXIT_ACCEPT = 42,
+	EXIT_REJECT = 43,
+	EXIT_JUDGE_FAILURE = 44,
+};
+
+/* util.cc: Utility functions */
+
+void accept(const char *msg, ...) NONRET;	// Report correct output
+void reject(const char *msg, ...) NONRET;	// Report wrong output
+void die(const char *msg, ...) NONRET;		// Dies with a judge error
+void *xmalloc(size_t size);
+void *xrealloc(void *p, size_t size);
+char *xstrdup(const char *str);
+
+/* io.cc: Simple buffered I/O streams */
+
+class stream {
+public:
+	char *name;
+
+	void open_read(const char *name);
+	void open_write(const char *name);
+	void open_fd(const char *name, int fd, bool want_close=true);
+	void flush();
+	stream();
+	~stream();
+
+	int getc()
+	{
+		return (pos < stop) ? *pos++ : getc_slow();
+	}
+
+	int peekc()
+	{
+		return (pos < stop) ? *pos : peekc_slow();
+	}
+
+	void putc(int c)
+	{
+		if (pos >= end)
+			flush();
+		*pos++ = c;
+	}
+
+	void ungetc()
+	{
+		assert(pos > buf);
+		pos--;
+	}
+
+private:
+	int fd;
+	bool want_close;
+	u8 *buf;
+	u8 *pos, *stop, *end;
+
+	int refill();
+	int getc_slow();
+	int peekc_slow();
+};
+
+/* token.cc: Tokenization of input */
+
+class tokenizer {
+public:
+	// Configurable parameters
+	uint maxsize;		// Maximal allowed token size
+	bool report_lines;	// Report an empty token at the end of each line
+
+	// Current token after get_token() is called
+	char *token;		// Current token (in the buffer)
+	uint toksize;		// ... and its size
+	uint line;		// ... and line number at its end
+
+	tokenizer(stream *source);
+	tokenizer(const char *source_file);
+	tokenizer(const char *source_name, int source_fd, bool want_close=true);
+	~tokenizer();
+	void reject(const char *msg, ...) NONRET;
+	char *get_token();	// Returns NULL at the end of input
+
+	// Parsing functions
+	bool to_int(int *x);
+	bool to_uint(unsigned int *x);
+	bool to_long(long int *x);
+	bool to_ulong(unsigned long int *x);
+	bool to_longlong(long long int *x);
+	bool to_ulonglong(unsigned long long int *x);
+	bool to_double(double *x);
+	bool to_long_double(long double *x);
+
+	// get_token() + parse or reject()
+	int get_int();
+	unsigned int get_uint();
+	long int get_long();
+	unsigned long int get_ulong();
+	long long int get_longlong();
+	unsigned long long int get_ulonglong();
+	double get_double();
+	long double get_long_double();
+	void get_nl();
+
+private:
+	stream *src;
+	bool close_src;
+	uint bufsize;		// Allocated buffer size
+	void init();
+};
+
+/* random.cc: Random generator */
+
+class random_generator {
+public:
+	random_generator(u64 seed) { _init(seed); }
+	random_generator(const char *hex_seed);
+	u64 next_u64();
+	u32 next_u32();
+	uint next_range(uint size);
+	uint next_range(uint start, uint past_end);
+
+	// Our RNG can be used as a random engine in the C++ standard library
+	using result_type = u32;
+	u32 operator () () { return next_u32(); }
+	static constexpr u32 min() { return 0; }
+	static constexpr u32 max() { return ~(u32)0; }
+
+private:
+	u64 state[2];
+	void _init(u64 seed);
+};
+
+#endif

--- a/pisek/tools/judgelib/random.cc
+++ b/pisek/tools/judgelib/random.cc
@@ -1,0 +1,66 @@
+/*
+ *	Random generator for judges
+ *
+ *	(c) 2022 Martin Mares <mj@ucw.cz>
+ */
+
+/*
+ * This is the xoroshiro128+ random generator, designed in 2016 by David Blackman
+ * and Sebastiano Vigna, distributed under the CC-0 license. For more details,
+ * see http://vigna.di.unimi.it/xorshift/.
+ *
+ * Rewritten to C++ by Martin Mares, also placed under CC-0.
+ */
+
+#include <cstdlib>
+#include <cstdio>
+
+using namespace std;
+
+#include "judge.h"
+
+void random_generator::_init(u64 seed)
+{
+	state[0] = seed * 0xdeadbeef;
+	state[1] = seed ^ 0xc0de1234;
+	for (int i=0; i<100; i++)
+	    next_u64();
+}
+
+random_generator::random_generator(const char *hex_seed)
+{
+	_init(strtoul(hex_seed, NULL, 16));
+}
+
+inline u64 rotl(u64 x, int k)
+{
+	return (x << k) | (x >> (64 - k));
+}
+
+u64 random_generator::next_u64()
+{
+	u64 s0 = state[0], s1 = state[1];
+	u64 result = s0 + s1;
+	s1 ^= s0;
+	state[0] = rotl(s0, 55) ^ s1 ^ (s1 << 14);
+	state[1] = rotl(s1, 36);
+	return result;
+}
+
+u32 random_generator::next_u32()
+{
+	return next_u64() >> 11;
+}
+
+uint random_generator::next_range(uint size)
+{
+	// This is not perfectly uniform, but since size is 32-bit
+	// and generator range 64-bit, the non-uniformity will be
+	// negligible.
+	return next_u64() % size;
+}
+
+uint random_generator::next_range(uint start, uint past_end)
+{
+	return start + next_range(past_end - start);
+}

--- a/pisek/tools/judgelib/token.cc
+++ b/pisek/tools/judgelib/token.cc
@@ -1,0 +1,213 @@
+/*
+ *	Tokenizer for judges
+ *
+ *	(c) 2021 Martin Mares <mj@ucw.cz>
+ *
+ *	Based on judge library from the Moe contest system by the same author.
+ *	Can be freely distributed and used under the terms of the GNU GPL v2 or later.
+ *
+ *	SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdarg>
+#include <cstring>
+#include <cctype>
+#include <limits.h>
+#include <errno.h>
+
+using namespace std;
+
+#include "judge.h"
+
+#define DEFAULT_MAX_TOKEN (32 << 20)
+
+void tokenizer::init()
+{
+	maxsize = DEFAULT_MAX_TOKEN;
+	report_lines = false;
+	bufsize = 1;
+
+	token = (char *) xmalloc(bufsize);
+	toksize = 0;
+	line = 1;
+}
+
+tokenizer::tokenizer(stream *source)
+{
+	src = source;
+	close_src = false;
+	init();
+}
+
+tokenizer::tokenizer(const char *source_file)
+{
+	src = new stream;
+	src->open_read(source_file);
+	close_src = true;
+	init();
+}
+
+tokenizer::tokenizer(const char *source_name, int source_fd, bool want_close)
+{
+	src = new stream;
+	src->open_fd(source_name, source_fd, want_close);
+	close_src = true;
+	init();
+}
+
+tokenizer::~tokenizer()
+{
+	free(token);
+	if (close_src)
+		delete src;
+}
+
+void tokenizer::reject(const char *msg, ...)
+{
+	va_list args;
+	va_start(args, msg);
+	fprintf(stderr, "Error at %s line %d: ", src->name, line);
+	vfprintf(stderr, msg, args);
+	fputc('\n', stderr);
+	va_end(args);
+	exit(43);
+}
+
+static bool is_white(int c)
+{
+  return (c == ' ' || c == '\t' || c == '\r' || c == '\n');
+}
+
+char *tokenizer::get_token()
+{
+	int c;
+
+	// Skip whitespace
+	do {
+		c = src->getc();
+		if (c < 0)
+			return NULL;
+		if (c == '\n') {
+			line++;
+			if (report_lines) {
+				toksize = 0;
+				token[0] = 0;
+				return token;
+			}
+		}
+	} while (is_white(c));
+
+	// This is the token itself
+	toksize = 0;
+	do {
+		token[toksize++] = c;
+		if (toksize >= bufsize) {
+			if (toksize > maxsize)
+				reject("Token too long");
+			bufsize *= 2;
+			if (bufsize > maxsize)
+				bufsize = maxsize + 1;
+			token = (char *) xrealloc(token, bufsize);
+		}
+		c = src->getc();
+	} while (c >= 0 && !is_white(c));
+
+	if (c >= 0)
+		src->ungetc();
+
+	token[toksize] = 0;
+	return token;
+}
+
+/*
+ *  Parsing functions.
+ */
+
+#define PARSE(f, ...)						\
+	char *end;						\
+	errno = 0;						\
+	if (!toksize)						\
+		return false;					\
+	if (isspace(*(unsigned char *)token))			\
+		return false;					\
+	*x = f(token, &end, ##__VA_ARGS__);			\
+	return !(errno || end != token + toksize)
+
+bool tokenizer::to_long(long int *x)
+{
+	PARSE(strtol, 10);
+}
+
+bool tokenizer::to_ulong(unsigned long int *x)
+{
+	if (token[0] == '-')		// strtoul accepts negative numbers, but we don't
+		return false;
+	PARSE(strtoul, 10);
+}
+
+bool tokenizer::to_longlong(long long int *x)
+{
+	PARSE(strtoll, 10);
+}
+
+bool tokenizer::to_ulonglong(unsigned long long int *x)
+{
+	if (token[0] == '-')		// strtoull accepts negative numbers, but we don't
+		return false;
+	PARSE(strtoull, 10);
+}
+
+bool tokenizer::to_double(double *x)
+{
+	PARSE(strtod);
+}
+
+bool tokenizer::to_long_double(long double *x)
+{
+	PARSE(strtold);
+}
+
+bool tokenizer::to_int(int *x)
+{
+	long int y;
+	if (!to_long(&y) || y > INT_MAX || y < INT_MIN)
+		return false;
+	*x = y;
+	return true;
+}
+
+bool tokenizer::to_uint(unsigned int *x)
+{
+	unsigned long int y;
+	if (!to_ulong(&y) || y > UINT_MAX)
+		return false;
+	*x = y;
+	return true;
+}
+
+#define GET(fn, type)									\
+	type tokenizer::get_##fn()							\
+	{										\
+		type x;									\
+		if (!get_token())							\
+			reject("Unexpected end of file");				\
+		if (!to_##fn(&x))							\
+			reject("Expected " #fn);					\
+		return x;								\
+	}
+
+GET(int, int)
+GET(uint, unsigned int)
+GET(long, long int)
+GET(ulong, unsigned long int)
+GET(double, double)
+GET(long_double, long double)
+
+void tokenizer::get_nl()
+{
+	char *tok = get_token();
+	if (tok && *tok)
+		reject("Expected end of line");
+}

--- a/pisek/tools/judgelib/util.cc
+++ b/pisek/tools/judgelib/util.cc
@@ -1,0 +1,73 @@
+/*
+ *	Utility functions for judges
+ *
+ *	(c) 2021 Martin Mares <mj@ucw.cz>
+ *
+ *	Based on judge library from the Moe contest system by the same author.
+ *	Can be freely distributed and used under the terms of the GNU GPL v2 or later.
+ *
+ *	SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdarg>
+#include <cstring>
+
+using namespace std;
+
+#include "judge.h"
+
+void accept(const char *msg, ...)
+{
+	va_list args;
+	va_start(args, msg);
+	vfprintf(stderr, msg, args);
+	fputc('\n', stderr);
+	va_end(args);
+	exit(EXIT_ACCEPT);
+}
+
+void reject(const char *msg, ...)
+{
+	va_list args;
+	va_start(args, msg);
+	vfprintf(stderr, msg, args);
+	fputc('\n', stderr);
+	va_end(args);
+	exit(EXIT_REJECT);
+}
+
+void die(const char *msg, ...)
+{
+	va_list args;
+	va_start(args, msg);
+	vfprintf(stderr, msg, args);
+	fputc('\n', stderr);
+	va_end(args);
+	exit(EXIT_JUDGE_FAILURE);
+}
+
+void *xmalloc(size_t size)
+{
+	void *p = malloc(size);
+	if (!p)
+		die("Out of memory (unable to allocate %z bytes)", size);
+	return p;
+}
+
+void *xrealloc(void *p, size_t size)
+{
+	p = realloc(p, size);
+	if (!p)
+		die("Out of memory (unable to allocate %z bytes)", size);
+	return p;
+}
+
+char *xstrdup(const char *str)
+{
+	size_t len = strlen(str) + 1;
+	char *copy = (char *) xmalloc(len);
+	memcpy(copy, str, len);
+	return copy;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ exclude = ["fixtures"]
 
 [tool.setuptools.package-data]
 pisek = [
-    "tools/*",
+    "tools/**",
     "config/*-defaults",
     "config/config-v3-documentation",
 ]


### PR DESCRIPTION
This PR imports KSP's `judgelib` judge utility library along with the `judge-token` program. It also adds support for using it instead of `diff`.

Both `out_check=diff` and `out_check=tokens` are supported. If we wan't to deprecate `diff` or alias it to `tokens`, we can easily do so in the future. It also supports all options supported by KSP's opendata tool.

One slight difference between this and KSP's implementation is that the floating point mode is disabled by setting `tokens_float_rel_error` and `tokens_float_abs_error` to `X` instead of the empty string.

Closes #173.