### PR TITLE
Minibox improvements

### DIFF
--- a/fixtures/guess/config
+++ b/fixtures/guess/config
@@ -34,9 +34,7 @@ in_globs=*.in
 
 [limits]
 # Time limit (seconds) for the model solution (first listed)
-solve_time_limit=2
-# Time limit (seconds) for other solutions
-sec_solve_time_limit=2
+solve_time_limit=0.2
 
 [solution_solve]
 primary=yes

--- a/fixtures/odd_stub/config
+++ b/fixtures/odd_stub/config
@@ -17,7 +17,7 @@ points=10
 in_globs=*.in
 
 [limits]
-solve_time_limit=1
+solve_time_limit=0.2
 
 [solution_solve]
 source=solve

--- a/fixtures/sum_cms/config
+++ b/fixtures/sum_cms/config
@@ -40,7 +40,7 @@ predecessors=1 2
 
 [limits]
 # Time limit (seconds) for solutions
-solve_time_limit=2
+solve_time_limit=0.2
 
 [solution_solve]
 source=solve

--- a/fixtures/sum_kasiopea/config
+++ b/fixtures/sum_kasiopea/config
@@ -48,6 +48,6 @@ subtasks=1WW
 
 [limits]
 # Time limit (seconds) for solutions
-solve_time_limit=1
+solve_time_limit=0.2
 # Memory (address space) limit (MB) for solutions
 solve_mem_limit=128

--- a/pisek/tools/minibox.c
+++ b/pisek/tools/minibox.c
@@ -40,6 +40,8 @@
 #define UNUSED __attribute__((unused))
 #define ARRAY_SIZE(a) (int)(sizeof(a)/sizeof(a[0]))
 
+#define TIMER_INTERVAL_US 100000
+
 static int timeout;			/* milliseconds */
 static int wall_timeout;
 static int extra_timeout;
@@ -408,7 +410,6 @@ signal_alarm(int unused UNUSED)
 {
   /* Time limit checks are synchronous, so we only schedule them there. */
   timer_tick = 1;
-  alarm(1);
 }
 
 static void
@@ -563,7 +564,11 @@ box_keeper(void)
       bzero(&sa, sizeof(sa));
       sa.sa_handler = signal_alarm;
       sigaction(SIGALRM, &sa, NULL);
-      alarm(1);
+      struct itimerval timer = {
+	.it_interval = { .tv_usec = TIMER_INTERVAL_US },
+	.it_value = { .tv_usec = TIMER_INTERVAL_US },
+      };
+      setitimer(ITIMER_REAL, &timer, NULL);
     }
 
   for(;;)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ class TestCLI(TestFixture):
         return "../fixtures/sum_cms/"
 
     def args(self):
-        return [["--timeout", "1"]]
+        return [["--timeout", "0.2"]]
 
     def runTest(self):
         if not self.fixture_path():

--- a/tests/util.py
+++ b/tests/util.py
@@ -124,7 +124,7 @@ class TestFixtureVariant(TestFixture):
                 inputs=1,
                 strict=False,
                 full=False,
-                timeout=1,
+                timeout=0.2,
                 plain=False,
             )
 


### PR DESCRIPTION
Minibox now ends at most tenth of second later then program instead of one second.

Also fixes #34 (a bit). Two seconds/test seem pretty reasonable anyway.