### PR TITLE
CMS: Add flag -a to act on active dataset

### DIFF
--- a/pisek/__main__.py
+++ b/pisek/__main__.py
@@ -86,12 +86,20 @@ def main(argv):
         )
 
     def add_argument_dataset(parser):
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             "--dataset",
             "-d",
             type=str,
             required=False,
             help="Use the dataset with the description DESCRIPTION.",
+        )
+
+        group.add_argument(
+            "--active-dataset",
+            "-a",
+            action="store_true",
+            help="Use the active dataset.",
         )
 
     # ------------------------------- pisek -------------------------------

--- a/pisek/cms/dataset.py
+++ b/pisek/cms/dataset.py
@@ -217,17 +217,20 @@ def add_headers(session: Session, files: FileCacher, env: Env, dataset: Dataset)
         session.add(Manager(dataset=dataset, filename=name, digest=header))
 
 
-def get_dataset(session: Session, task: Task, description: Optional[str]) -> Dataset:
-    if description is None:
-        datasets = session.query(Dataset).filter(Dataset.task == task).all()
+def get_only_dataset(session: Session, task: Task) -> Dataset:
+    datasets = session.query(Dataset).filter(Dataset.task == task).all()
 
-        if len(datasets) >= 2:
-            raise RuntimeError(
-                f"The task has multiple datasets: {', '.join(d.description for d in datasets)}"
-            )
-        else:
-            return datasets[0]
+    if len(datasets) >= 2:
+        raise RuntimeError(
+            f"The task has multiple datasets: {', '.join(sorted(d.description for d in datasets))}"
+        )
+    else:
+        return datasets[0]
 
+
+def get_dataset_by_description(
+    session: Session, task: Task, description: str
+) -> Dataset:
     try:
         return (
             session.query(Dataset)


### PR DESCRIPTION
This PR adds a flag named `--active-dataset` (or just `-a`) that allows the user to select the active dataset for `cms check` or `cms testing-log` without having to remember its name. 

Somewhat fixes #182