### PR TITLE
ConfigDescription: Change checking unused keys

### DIFF
--- a/pisek/config/config_description.py
+++ b/pisek/config/config_description.py
@@ -55,7 +55,7 @@ class ConfigSectionDescription:
 
     def similarity(self, section: str) -> int:
         if self.similarity_function is None:
-            return 5 * (self.section != section)
+            return 5 if self.section != section else 0
         else:
             return self.similarity_function(self.section, section)
 


### PR DESCRIPTION
1. Now checks keys according to `config-description` and not to their usage. This allows keys to be overshadowed by other keys.
2. Improved error messages for context-specific keys.
3. Made key recommendations more predictable. It can now recommend key that is not allowed in this context, but in such cases you probably need to look up config documentation anyway. 