### PR TITLE
ConfigDocs: Remove solutions_subdir

### DIFF
--- a/docs/config-v3-documentation
+++ b/docs/config-v3-documentation
@@ -34,8 +34,6 @@ task_type=communication
 score_precision=0
 # How many decimal digits scores are rounded to (defaults to 0)
 
-solutions_subdir=solutions/
-# Try to find solutions in this folder relative to config (defaults to .)
 static_subdir=static_tests/
 # Try to find static inputs and outputs in this folder relative to config (defaults to .)
 


### PR DESCRIPTION
Remove solution_subdir from documentation as it was replaces by `[run_solution] subdir`