### PR TITLE
Config: Move static_subdir to [tests] and name to [cms]

### DIFF
--- a/docs/config-v3-documentation
+++ b/docs/config-v3-documentation
@@ -20,9 +20,6 @@ version=v3
 
 # You can use 'pisek update' to update the config to the highest version.
 
-name=a-plus-b
-# Name of task (for automatic CMS import) (required)
-
 use=organization-config
 # Config to use defaults from (defaults to none)
 
@@ -33,9 +30,6 @@ task_type=communication
 
 score_precision=0
 # How many decimal digits scores are rounded to (defaults to 0)
-
-static_subdir=static_tests/
-# Try to find static inputs and outputs in this folder relative to config (defaults to .)
 
 [tests]
 
@@ -135,6 +129,9 @@ shuffle_mode=lines
 shuffle_ignore_case=0
 # Only for out_check=shuffle
 # If set to 1, ASCII characters will be compared in a case-insensitive manner (defaults to 0)
+
+static_subdir=static_tests/
+# Try to find static inputs and outputs in this folder relative to config (defaults to .)
 
 [test01]
 # Section for each test (indexed from one)
@@ -321,6 +318,8 @@ generator_respects_seed=on
 # Settings related to the CMS importer
 # See CMS docs (https://cms.readthedocs.io/en/latest/) for details
 
+name=a-plus-b
+# Name of task, which will appear in the task URL (required for CMS commands)
 title=A plus B
 # The name of the task shown on the task description page 
 # @name expands to the task name (default)

--- a/fixtures/guess/config
+++ b/fixtures/guess/config
@@ -2,7 +2,6 @@
 # Source: $(pisek)/docs/config-v3-documentation for more information
 
 [task]
-name=guess
 # CMS tasks have a different judge and generator format than Kasiopea
 # (generator doesn't require seed)
 use=communication
@@ -43,3 +42,6 @@ tests=1P
 [solution_solve_0b]
 points=0
 tests=1W
+
+[cms]
+name=guess

--- a/fixtures/odd_stub/config
+++ b/fixtures/odd_stub/config
@@ -2,7 +2,6 @@
 # Source: $(pisek)/docs/config-v2-documentation for more information
 
 [task]
-name=odd-stub
 contest_type=cms
 version=v2
 
@@ -30,3 +29,6 @@ subtasks=11
 
 [solution_solve_rev]
 subtasks=11
+
+[cms]
+name=odd-stub

--- a/fixtures/sum_cms/config
+++ b/fixtures/sum_cms/config
@@ -2,7 +2,6 @@
 # Source: $(pisek)/docs/config-v2-documentation for more information
 
 [task]
-name=sum-cms
 # CMS tasks have a different judge and generator format than Kasiopea
 # (generator doesn't require seed)
 contest_type=cms
@@ -68,6 +67,7 @@ points=0
 subtasks=WWWW
 
 [cms]
+name=sum
 title=Sum
 time_limit=2
 min_submission_interval=30

--- a/fixtures/sum_kasiopea/config
+++ b/fixtures/sum_kasiopea/config
@@ -2,7 +2,6 @@
 # Source: $(pisek)/docs/config-v3-documentation for more information
 
 [task]
-name=sum-kasiopea
 tests=2
 
 version=v2

--- a/pisek/cms/__init__.py
+++ b/pisek/cms/__init__.py
@@ -75,8 +75,16 @@ def generate_testcases(env: Env) -> list[InputPath]:
     return pipeline.input_dataset()
 
 
+def check_config(env: Env):
+    if env.config.cms.name is None:
+        raise RuntimeError(
+            "The name key in the [cms] section must be set to run CMS commands."
+        )
+
+
 @with_env
 def create(env: Env, args: Namespace) -> int:
+    check_config(env)
     testcases = generate_testcases(env)
     session = Session()
 
@@ -100,6 +108,7 @@ def create(env: Env, args: Namespace) -> int:
 
 @with_env
 def update(env: Env, args: Namespace) -> int:
+    check_config(env)
     session = Session()
 
     task = get_task(session, env.config)
@@ -113,6 +122,7 @@ def update(env: Env, args: Namespace) -> int:
 
 @with_env
 def add(env: Env, args: Namespace) -> int:
+    check_config(env)
     testcases = generate_testcases(env)
     session = Session()
 
@@ -135,6 +145,7 @@ def add(env: Env, args: Namespace) -> int:
 
 @with_env
 def submit(env: Env, args: Namespace) -> int:
+    check_config(env)
     session = Session()
 
     username = args.username
@@ -161,6 +172,7 @@ def get_dataset_from_args(session: SessionType, task: Task, args: Namespace) -> 
 
 @with_env
 def testing_log(env: Env, args: Namespace) -> int:
+    check_config(env)
     session = Session()
 
     task = get_task(session, env.config)
@@ -172,6 +184,7 @@ def testing_log(env: Env, args: Namespace) -> int:
 
 @with_env
 def check(env: Env, args: Namespace) -> int:
+    check_config(env)
     session = Session()
 
     task = get_task(session, env.config)

--- a/pisek/cms/dataset.py
+++ b/pisek/cms/dataset.py
@@ -142,7 +142,7 @@ def add_judge(session: Session, files: FileCacher, env: Env, dataset: Dataset):
 
     judge = files.put_file_from_path(
         TaskPath.executable_path(env, config.out_judge).path,
-        f"{judge_name} for {config.name}",
+        f"{judge_name} for {config.cms.name}",
     )
     session.add(Manager(dataset=dataset, filename=judge_name, digest=judge))
 
@@ -185,7 +185,7 @@ def add_stubs(session: Session, files: FileCacher, env: Env, dataset: Dataset):
 
         stub = files.put_file_from_path(
             path.join(directory, filename),
-            f"{stub_basename}{ext} for {config.name}",
+            f"{stub_basename}{ext} for {config.cms.name}",
         )
         session.add(
             Manager(dataset=dataset, filename=f"{stub_basename}{ext}", digest=stub)
@@ -198,7 +198,7 @@ def add_stubs(session: Session, files: FileCacher, env: Env, dataset: Dataset):
             continue
 
         stub = files.put_file_content(
-            content.encode(), f"{stub_basename}{ext} for {config.name}"
+            content.encode(), f"{stub_basename}{ext} for {config.cms.name}"
         )
         session.add(
             Manager(dataset=dataset, filename=f"{stub_basename}{ext}", digest=stub)
@@ -211,7 +211,7 @@ def add_headers(session: Session, files: FileCacher, env: Env, dataset: Dataset)
     for header in config.headers:
         name = header.name
         header = files.put_file_from_path(
-            header.path, f"Header {name} for {config.name}"
+            header.path, f"Header {name} for {config.cms.name}"
         )
         session.add(Manager(dataset=dataset, filename=name, digest=header))
 

--- a/pisek/cms/task.py
+++ b/pisek/cms/task.py
@@ -26,7 +26,7 @@ def create_task(
 ) -> Task:
     config = env.config
 
-    task = Task(name=config.name, title=config.cms.title)
+    task = Task(name=config.cms.name, title=config.cms.title)
     set_task_settings(task, config)
 
     dataset = create_dataset(session, env, task, testcases, description)
@@ -53,6 +53,6 @@ def set_task_settings(task: Task, config: TaskConfig):
 
 def get_task(session: Session, config: TaskConfig):
     try:
-        return session.query(Task).filter(Task.name == config.name).one()
+        return session.query(Task).filter(Task.name == config.cms.name).one()
     except NoResultFound as e:
         raise RuntimeError("This task has not been imported into CMS yet") from e

--- a/pisek/config/cms-defaults
+++ b/pisek/config/cms-defaults
@@ -4,13 +4,13 @@
 version=v3
 task_type=batch
 score_precision=0
-static_subdir=.
 
 [tests]
 gen_type=cms-old
 checker=
 judge_needs_in=1
 judge_needs_out=1
+static_subdir=.
 
 [all_tests]
 name=@auto 
@@ -54,6 +54,7 @@ all_inputs_in_last_test=off
 generator_respects_seed=on
 
 [cms]
+name=
 title=@name
 submission_format=@name
 

--- a/pisek/config/config-description
+++ b/pisek/config/config-description
@@ -1,10 +1,8 @@
 [task]
 version=
-name=
 use=
 task_type=
 score_precision=
-static_subdir=
 
 [tests]
 in_gen=
@@ -38,6 +36,8 @@ shuffle_mode=
 #!if tests out_check=shuffle
 shuffle_ignore_case=
 #!if tests out_check=shuffle
+
+static_subdir=
 
 [test\d{2}]
 #!regex
@@ -216,6 +216,7 @@ all_inputs_in_last_test=
 generator_respects_seed=
 
 [cms]
+name=
 title=
 submission_format=
 time_limit=

--- a/pisek/config/global-defaults
+++ b/pisek/config/global-defaults
@@ -2,7 +2,6 @@
 version=v3
 task_type=batch
 score_precision=0
-static_subdir=.
 
 [tests]
 checker=
@@ -15,6 +14,7 @@ tokens_float_abs_error=
 shuffle_ignore_case=0
 in_format=text
 out_format=text
+static_subdir=.
 
 [all_tests]
 name=@auto
@@ -58,6 +58,7 @@ all_inputs_in_last_test=off
 generator_respects_seed=on
 
 [cms]
+name=
 title=@name
 submission_format=@name
 

--- a/pisek/config/kasiopea-defaults
+++ b/pisek/config/kasiopea-defaults
@@ -4,7 +4,6 @@
 version=v3
 task_type=batch
 score_precision=0
-static_subdir=.
 
 [tests]
 gen_type=opendata-v1
@@ -12,6 +11,7 @@ checker=
 judge_type=opendata-v1
 judge_needs_in=1
 judge_needs_out=1
+static_subdir=.
 
 [all_tests]
 name=@auto 
@@ -55,6 +55,7 @@ all_inputs_in_last_test=off
 generator_respects_seed=on
 
 [cms]
+name=
 title=@name
 submission_format=@name
 

--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -91,7 +91,6 @@ def _to_values(config_values_dict: ConfigValuesDict) -> ValuesDict:
 class TaskConfig(BaseEnv):
     """Configuration of task loaded from config file."""
 
-    name: str
     task_type: TaskType
     score_precision: int = Field(ge=0)
 
@@ -190,7 +189,7 @@ class TaskConfig(BaseEnv):
         return next(sources, None)
 
     def __init__(self, **kwargs):
-        value = {"test_count": max(kwargs["tests"]) + 1, "name": kwargs["name"]}
+        value = {"test_count": max(kwargs["tests"]) + 1}
 
         with init_context(value):
             super().__init__(**kwargs)
@@ -198,16 +197,15 @@ class TaskConfig(BaseEnv):
     @staticmethod
     def load_dict(configs: ConfigHierarchy) -> ConfigValuesDict:
         GLOBAL_KEYS = [
-            ("task", "name"),
             ("task", "task_type"),
             ("task", "score_precision"),
-            ("task", "static_subdir"),
             ("tests", "in_gen"),
             ("tests", "gen_type"),
             ("tests", "checker"),
             ("tests", "out_check"),
             ("tests", "in_format"),
             ("tests", "out_format"),
+            ("tests", "static_subdir"),
             ("all_solutions", "stub"),
             ("all_solutions", "headers"),
         ]
@@ -688,6 +686,7 @@ class LimitsConfig(BaseEnv):
 class CMSConfig(BaseEnv):
     _section: str = "cms"
 
+    name: OptionalStr
     title: str
     submission_format: ListStr
 
@@ -703,6 +702,7 @@ class CMSConfig(BaseEnv):
     @classmethod
     def load_dict(cls, configs: ConfigHierarchy) -> ConfigValuesDict:
         KEYS = [
+            "name",
             "title",
             "submission_format",
             "time_limit",
@@ -722,7 +722,7 @@ class CMSConfig(BaseEnv):
             if info.context is None:
                 raise RuntimeError(MISSING_VALIDATION_CONTEXT)
 
-            return info.context.get("name")
+            return info.context.get("name", "unnamed-task")
         else:
             return value
 
@@ -734,7 +734,9 @@ class CMSConfig(BaseEnv):
 
         return [
             (
-                CMSConfig.get_default_file_name(info.context.get("name"))
+                CMSConfig.get_default_file_name(
+                    info.context.get("name", "unnamed-task")
+                )
                 if n == "@name"
                 else n
             )


### PR DESCRIPTION
As pointed out by Martin Mareš, `static_subdir` doesn't really belong in `[task]`, and `name` is only needed for the CMS importer.