### PR TITLE
Solution: Fix overlapping inputs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,9 @@
             "module": "pisek.__main__",
             "console": "integratedTerminal",
             "justMyCode": true,
-            "cwd": "${workspaceFolder}/fixtures/",
+            "cwd": "${workspaceFolder}/fixtures",
             "args": ["test"],
+            "env": {"PISEK_DIRECTORY": "${workspaceFolder}/fixtures/pisek"}
         }
     ]
 }

--- a/fixtures/guess/config
+++ b/fixtures/guess/config
@@ -24,6 +24,7 @@ headers=src/guess.h
 name=Test A
 points=10
 in_globs=*.in
+predecessors=0
 
 [run_solution]
 # Time limit (seconds) for the solutions

--- a/pisek/task_jobs/generator/manager.py
+++ b/pisek/task_jobs/generator/manager.py
@@ -137,8 +137,11 @@ class TestcaseInfoMixin(JobManager):
         jobs: list[Job] = []
         self._gen_inputs_job = {}
 
+        skipped: bool = False
         for i, seed in enumerate(seeds):
             if self._skip_testcase(testcase_info, seed, test):
+                skipped = True
+                self._register_skipped_testcase(testcase_info, seed, test)
                 continue
 
             self.inputs.add(testcase_info.input_path(self._env, seed))
@@ -150,7 +153,11 @@ class TestcaseInfoMixin(JobManager):
 
             jobs += inp_jobs + out_jobs
 
-        if self._env.config.checks.generator_respects_seed and testcase_info.seeded:
+        if (
+            self._env.config.checks.generator_respects_seed
+            and testcase_info.seeded
+            and not skipped
+        ):
             jobs += self._respects_seed_jobs(
                 testcase_info, cast(list[int], seeds), test
             )
@@ -160,6 +167,11 @@ class TestcaseInfoMixin(JobManager):
         self, testcase_info: TestcaseInfo, seed: Optional[int], test: int
     ) -> bool:
         return testcase_info.input_path(self._env, seed) in self.inputs
+
+    def _register_skipped_testcase(
+        self, testcase_info: TestcaseInfo, seed: Optional[int], test: int
+    ) -> None:
+        pass
 
     def _generate_input_jobs(
         self,
@@ -227,11 +239,6 @@ class TestcaseInfoMixin(JobManager):
             testcase_info.generation_mode == TestcaseGenerationMode.generated
             and testcase_info.seeded
         )
-
-        if not self._env.config.tests[test].new_in_test(
-            testcase_info.input_path(self._env, seeds[0]).name
-        ):
-            return []
 
         jobs: list[Job] = []
 

--- a/pisek/task_jobs/generator/manager.py
+++ b/pisek/task_jobs/generator/manager.py
@@ -159,9 +159,7 @@ class TestcaseInfoMixin(JobManager):
     def _skip_testcase(
         self, testcase_info: TestcaseInfo, seed: Optional[int], test: int
     ) -> bool:
-        return not self._env.config.tests[test].new_in_test(
-            testcase_info.input_path(self._env, seed).name
-        )
+        return testcase_info.input_path(self._env, seed) in self.inputs
 
     def _generate_input_jobs(
         self,

--- a/pisek/task_jobs/solution/manager.py
+++ b/pisek/task_jobs/solution/manager.py
@@ -74,22 +74,18 @@ class SolutionManager(TaskJobManager, TestcaseInfoMixin):
 
         return jobs
 
-    def _skip_testcase(
+    def _register_skipped_testcase(
         self, testcase_info: TestcaseInfo, seed: Optional[int], test: int
-    ) -> bool:
-        skip = super()._skip_testcase(testcase_info, seed, test)
-        if skip:
-            input_path = testcase_info.input_path(
-                self._env, seed, solution=self.solution_label
-            )
-            if self._env.config.tests[test].new_in_test(input_path.name):
-                self.tests[-1].new_run_jobs.append(self._sols[input_path])
-                self.tests[-1].new_jobs.append(self._judges[input_path])
-                self._sols[input_path].require()
-            else:
-                self.tests[-1].previous_jobs.append(self._judges[input_path])
-
-        return skip
+    ) -> None:
+        input_path = testcase_info.input_path(
+            self._env, seed, solution=self.solution_label
+        )
+        if self._env.config.tests[test].new_in_test(input_path.name):
+            self.tests[-1].new_run_jobs.append(self._sols[input_path])
+            self.tests[-1].new_jobs.append(self._judges[input_path])
+            self._sols[input_path].require()
+        else:
+            self.tests[-1].previous_jobs.append(self._judges[input_path])
 
     def _generate_input_jobs(
         self,

--- a/pisek/task_jobs/solution/solution.py
+++ b/pisek/task_jobs/solution/solution.py
@@ -36,8 +36,18 @@ class RunSolution(ProgramsJob):
         **kwargs,
     ) -> None:
         super().__init__(env=env, name=name, **kwargs)
+        self._needed_by = 1
         self.solution = solution
         self.is_primary = is_primary
+
+    def require(self):
+        self._needed_by += 1
+
+    def unrequire(self):
+        self._needed_by -= 1
+        if self._needed_by == 0:
+            self.cancel()
+        assert self._needed_by >= 0
 
     def _solution_type(self) -> ProgramType:
         return (


### PR DESCRIPTION
When inputs overlap between tests by using `in_globs` directly (and not predeccessors), it could lead to wrong cancelations and testing logs.