### PR TITLE
Data: Report proper name of generated sample in error message

### DIFF
--- a/pisek/task_jobs/data/manager.py
+++ b/pisek/task_jobs/data/manager.py
@@ -77,7 +77,7 @@ class DataManager(TaskJobManager, TestcaseInfoMixin):
         for testcase_info in self._testcase_infos[0]:
             if testcase_info.generation_mode != TestcaseGenerationMode.static:
                 raise PipelineItemFailure(
-                    f"Sample inputs must be static, but '{inp_path}' is {testcase_info.generation_mode}."
+                    f"Sample inputs must be static, but '{testcase_info.name}' is {testcase_info.generation_mode}."
                 )
 
         used_inputs = set(sum(self._testcase_infos.values(), start=[]))


### PR DESCRIPTION
Fixes the error message that's shown when a sample input isn't static to include the name of that input, instead of the last input globally.