### PR TITLE
Tools: Overwrite when linking truncated output

### DIFF
--- a/pisek/task_jobs/tools.py
+++ b/pisek/task_jobs/tools.py
@@ -180,7 +180,7 @@ class SanitizeAbstact(TaskJob):
     def _run(self) -> None:
         result = self.prerequisites_results.get("create_source", None)
         if isinstance(result, RunResult) and result.kind != RunResultKind.OK:
-            self._link_file(self.input, self.output)
+            self._link_file(self.input, self.output, overwrite=True)
             return
 
         self._sanitize()


### PR DESCRIPTION
This PR makes it possible to run a failing solution a second time without running `pisek clean` first.
